### PR TITLE
Fix the fatal error which result from execting 'ipmitool fru internaluse 1 info'

### DIFF
--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -4095,7 +4095,6 @@ ipmi_fru_get_internal_use_info(  struct ipmi_intf * intf,
 		return -1;
 	}
 
-	memset(&fru, 0, sizeof(fru));
 	fru->size = (rsp->data[1] << 8) | rsp->data[0];
 	fru->access = rsp->data[2] & 0x1;
 


### PR DESCRIPTION
Executing "ipmitool fru internaluse 1 info" command and run into the line #4098 which is within ipmi_fru_get_internal_use_info() function will result to segmentation fault.