### PR TITLE
plugins/open: Fix for interrupted select

### DIFF
--- a/src/plugins/open/open.c
+++ b/src/plugins/open/open.c
@@ -335,7 +335,9 @@ ipmi_openipmi_send_cmd(struct ipmi_intf * intf, struct ipmi_rq * req)
 	FD_SET(intf->fd, &rset);
 	read_timeout.tv_sec = IPMI_OPENIPMI_READ_TIMEOUT;
 	read_timeout.tv_usec = 0;
-	retval = select(intf->fd+1, &rset, NULL, NULL, &read_timeout);
+	do {
+		retval = select(intf->fd+1, &rset, NULL, NULL, &read_timeout);
+	} while (retval < 0 && errno == EINTR);
 	if (retval < 0) {
 	   lperror(LOG_ERR, "I/O Error");
 	   if (data != NULL) {


### PR DESCRIPTION
The select syscall can be interrupted for signals like SIGPROF. The IPMI
command sent will still be outstanding but the send_command will return
an error. When the next command is sent it will get the completion for
the previous command and has the tendency to break state of end users.