### PR TITLE
mc: Always return negative value on error

### DIFF
--- a/lib/ipmi_mc.c
+++ b/lib/ipmi_mc.c
@@ -1367,12 +1367,16 @@ ipmi_sysinfo_main(struct ipmi_intf *intf, int argc, char ** argv, int is_set)
 	if (rc < 0) {
 		lprintf(LOG_ERR, "%s %s set %d command failed", argv[0], argv[1], set);
 	}
-	else if (rc == 0x80) {
-		lprintf(LOG_ERR, "%s %s parameter not supported", argv[0], argv[1]);
-	}
 	else if (rc > 0) {
-		lprintf(LOG_ERR, "%s command failed: %s", argv[0],
-		        CC_STRING(rc));
+		if (rc == 0x80) {
+			lprintf(LOG_ERR, "%s %s parameter not supported", argv[0],
+				argv[1]);
+		}
+		else {
+			lprintf(LOG_ERR, "%s command failed: %s", argv[0],
+			        CC_STRING(rc));
+		}
+		rc = -rc;
 	}
 	return rc;
 }


### PR DESCRIPTION
ipmitool main() only considers negative return values to be an error.
ipmi_sysinfo_main can return a positive error when a command fails. When
this occurs the mc command prints an error message but the return code
from ipmitool is 0. By negating the return code in ipmi_sysinfo_main
main will return a non 0 exit status.

Signed-off-by: Nate Clark <nate.clark@hitachivantara.com>