### PR TITLE
Auto selection of 'best' cipher suite available

### DIFF
--- a/include/ipmitool/ipmi_channel.h
+++ b/include/ipmitool/ipmi_channel.h
@@ -119,8 +119,8 @@ struct oem_cipher_suite_record_t {
  * records.
  */
 #define MAX_CIPHER_SUITE_COUNT (MAX_CIPHER_SUITE_RECORD_OFFSET * \
-		MAX_CIPHER_SUITE_DATA_LEN / \
-		sizeof(struct std_cipher_suite_record_t))
+                                MAX_CIPHER_SUITE_DATA_LEN / \
+                                sizeof(struct std_cipher_suite_record_t))
 
 /*
  * The Get Authentication Capabilities response structure
@@ -174,20 +174,25 @@ struct get_channel_auth_cap_rsp {
 #endif
 
 int _ipmi_get_channel_access(struct ipmi_intf *intf,
-		struct channel_access_t *channel_access,
-		uint8_t get_volatile_settings);
-int ipmi_get_channel_cipher_suites(struct ipmi_intf *intf, const char *payload_type,
-		uint8_t channel, struct cipher_suite_info *suites, size_t *count);
+                             struct channel_access_t *channel_access,
+                             uint8_t get_volatile_settings);
+int ipmi_get_channel_cipher_suites(struct ipmi_intf *intf,
+                                   const char *payload_type,
+                                   uint8_t channel,
+                                   struct cipher_suite_info *suites,
+                                   size_t *count);
 int _ipmi_get_channel_info(struct ipmi_intf *intf,
-        struct channel_info_t *channel_info);
+                           struct channel_info_t *channel_info);
 int _ipmi_set_channel_access(struct ipmi_intf *intf,
-		struct channel_access_t channel_access, uint8_t access_option,
-		uint8_t privilege_option);
+                             struct channel_access_t channel_access,
+                             uint8_t access_option,
+                             uint8_t privilege_option);
 
 uint8_t ipmi_get_channel_medium(struct ipmi_intf * intf, uint8_t channel);
 uint8_t ipmi_current_channel_medium(struct ipmi_intf * intf);
 int ipmi_channel_main(struct ipmi_intf * intf, int argc, char ** argv);
-int ipmi_get_channel_auth_cap(struct ipmi_intf * intf, uint8_t channel, uint8_t priv);
+int ipmi_get_channel_auth_cap(struct ipmi_intf * intf,
+                              uint8_t channel, uint8_t priv);
 int ipmi_get_channel_info(struct ipmi_intf * intf, uint8_t channel);
 
 #endif /*IPMI_CHANNEL_H*/

--- a/include/ipmitool/ipmi_intf.h
+++ b/include/ipmitool/ipmi_intf.h
@@ -62,13 +62,45 @@ enum LANPLUS_SESSION_STATE {
 #define IPMI_SIK_BUFFER_SIZE      IPMI_MAX_MD_SIZE
 #define IPMI_KG_BUFFER_SIZE       21 /* key plus null byte */
 
+enum cipher_suite_ids {
+	IPMI_LANPLUS_CIPHER_SUITE_0 = 0,
+	IPMI_LANPLUS_CIPHER_SUITE_1 = 1,
+	IPMI_LANPLUS_CIPHER_SUITE_2 = 2,
+	IPMI_LANPLUS_CIPHER_SUITE_3 = 3,
+	IPMI_LANPLUS_CIPHER_SUITE_4 = 4,
+	IPMI_LANPLUS_CIPHER_SUITE_5 = 5,
+	IPMI_LANPLUS_CIPHER_SUITE_6 = 6,
+	IPMI_LANPLUS_CIPHER_SUITE_7 = 7,
+	IPMI_LANPLUS_CIPHER_SUITE_8 = 8,
+	IPMI_LANPLUS_CIPHER_SUITE_9 = 9,
+	IPMI_LANPLUS_CIPHER_SUITE_10 = 10,
+	IPMI_LANPLUS_CIPHER_SUITE_11 = 11,
+	IPMI_LANPLUS_CIPHER_SUITE_12 = 12,
+	IPMI_LANPLUS_CIPHER_SUITE_13 = 13,
+	IPMI_LANPLUS_CIPHER_SUITE_14 = 14,
+#ifdef HAVE_CRYPTO_SHA256
+	IPMI_LANPLUS_CIPHER_SUITE_15 = 15,
+	IPMI_LANPLUS_CIPHER_SUITE_16 = 16,
+	IPMI_LANPLUS_CIPHER_SUITE_17 = 17,
+#endif /* HAVE_CRYPTO_SHA256 */
+	IPMI_LANPLUS_CIPHER_SUITE_RESERVED = 0xff,
+};
+
+struct cipher_suite_info {
+	enum cipher_suite_ids cipher_suite_id;
+	uint8_t auth_alg;
+	uint8_t integrity_alg;
+	uint8_t crypt_alg;
+	uint32_t iana;
+};
+
 struct ipmi_session_params {
 	char * hostname;
 	uint8_t username[17];
 	uint8_t authcode_set[IPMI_AUTHCODE_BUFFER_SIZE + 1];
 	uint8_t authtype_set;
 	uint8_t privlvl;
-	uint8_t cipher_suite_id;
+	enum cipher_suite_ids cipher_suite_id;
 	char sol_escape_char;
 	int password;
 	int port;
@@ -217,7 +249,10 @@ void ipmi_intf_session_set_username(struct ipmi_intf * intf, char * username);
 void ipmi_intf_session_set_password(struct ipmi_intf * intf, char * password);
 void ipmi_intf_session_set_privlvl(struct ipmi_intf * intf, uint8_t privlvl);
 void ipmi_intf_session_set_lookupbit(struct ipmi_intf * intf, uint8_t lookupbit);
-void ipmi_intf_session_set_cipher_suite_id(struct ipmi_intf * intf, uint8_t cipher_suite_id);
+#ifdef IPMI_INTF_LANPLUS
+void ipmi_intf_session_set_cipher_suite_id(struct ipmi_intf * intf,
+		enum cipher_suite_ids cipher_suite_id);
+#endif /* IPMI_INTF_LANPLUS */
 void ipmi_intf_session_set_sol_escape_char(struct ipmi_intf * intf, char sol_escape_char);
 void ipmi_intf_session_set_kgkey(struct ipmi_intf *intf, const uint8_t *kgkey);
 void ipmi_intf_session_set_port(struct ipmi_intf * intf, int port);

--- a/include/ipmitool/ipmi_intf.h
+++ b/include/ipmitool/ipmi_intf.h
@@ -251,7 +251,7 @@ void ipmi_intf_session_set_privlvl(struct ipmi_intf * intf, uint8_t privlvl);
 void ipmi_intf_session_set_lookupbit(struct ipmi_intf * intf, uint8_t lookupbit);
 #ifdef IPMI_INTF_LANPLUS
 void ipmi_intf_session_set_cipher_suite_id(struct ipmi_intf * intf,
-		enum cipher_suite_ids cipher_suite_id);
+                                           enum cipher_suite_ids cipher_suite_id);
 #endif /* IPMI_INTF_LANPLUS */
 void ipmi_intf_session_set_sol_escape_char(struct ipmi_intf * intf, char sol_escape_char);
 void ipmi_intf_session_set_kgkey(struct ipmi_intf *intf, const uint8_t *kgkey);

--- a/lib/ipmi_main.c
+++ b/lib/ipmi_main.c
@@ -318,6 +318,7 @@ ipmi_main(int argc, char ** argv,
 	uint8_t target_addr = 0;
 	uint8_t target_channel = 0;
 
+	uint8_t u8tmp = 0;
 	uint8_t transit_addr = 0;
 	uint8_t transit_channel = 0;
 	uint8_t target_lun     = 0;
@@ -425,17 +426,14 @@ ipmi_main(int argc, char ** argv,
 			break;
 #ifdef IPMI_INTF_LANPLUS
 		case 'C':
-			if (str2int(optarg, &cipher_suite_id) != 0) {
-				lprintf(LOG_ERR, "Invalid parameter given or out of range for '-C'.");
+			/* Cipher Suite ID is a byte as per IPMI specification */
+			if (str2uchar(optarg, &u8tmp) != 0) {
+				lprintf(LOG_ERR, "Invalid parameter given or out of "
+				                 "range [0-255] for '-C'.");
 				rc = -1;
 				goto out_free;
 			}
-			/* add check Cipher is -gt 0 */
-			if (cipher_suite_id < 0) {
-				lprintf(LOG_ERR, "Cipher suite ID %i is invalid.", cipher_suite_id);
-				rc = -1;
-				goto out_free;
-			}
+			cipher_suite_id = u8tmp;
 			break;
 #endif /* IPMI_INTF_LANPLUS */
 		case 'v':

--- a/lib/ipmi_main.c
+++ b/lib/ipmi_main.c
@@ -342,7 +342,10 @@ ipmi_main(int argc, char ** argv,
 	char * seloem   = NULL;
 	int port = 0;
 	int devnum = 0;
-	int cipher_suite_id = 3; /* See table 22-19 of the IPMIv2 spec */
+#ifdef IPMI_INTF_LANPLUS
+	/* lookup best cipher suite available */
+	enum cipher_suite_ids cipher_suite_id = IPMI_LANPLUS_CIPHER_SUITE_RESERVED;
+#endif /* IPMI_INTF_LANPLUS */
 	int argflag, i, found;
 	int rc = -1;
 	int ai_family = AF_UNSPEC;
@@ -420,6 +423,7 @@ ipmi_main(int argc, char ** argv,
 				goto out_free;
 			}
 			break;
+#ifdef IPMI_INTF_LANPLUS
 		case 'C':
 			if (str2int(optarg, &cipher_suite_id) != 0) {
 				lprintf(LOG_ERR, "Invalid parameter given or out of range for '-C'.");
@@ -433,6 +437,7 @@ ipmi_main(int argc, char ** argv,
 				goto out_free;
 			}
 			break;
+#endif /* IPMI_INTF_LANPLUS */
 		case 'v':
 			verbose++;
 			break;
@@ -868,7 +873,9 @@ ipmi_main(int argc, char ** argv,
 
 	ipmi_intf_session_set_lookupbit(ipmi_main_intf, lookupbit);
 	ipmi_intf_session_set_sol_escape_char(ipmi_main_intf, sol_escape_char);
+#ifdef IPMI_INTF_LANPLUS
 	ipmi_intf_session_set_cipher_suite_id(ipmi_main_intf, cipher_suite_id);
+#endif /* IPMI_INTF_LANPLUS */
 
 	ipmi_main_intf->devnum = devnum;
 

--- a/src/plugins/ipmi_intf.c
+++ b/src/plugins/ipmi_intf.c
@@ -249,11 +249,14 @@ ipmi_intf_session_set_lookupbit(struct ipmi_intf * intf, uint8_t lookupbit)
 	intf->ssn_params.lookupbit = lookupbit;
 }
 
+#ifdef IPMI_INTF_LANPLUS
 void
-ipmi_intf_session_set_cipher_suite_id(struct ipmi_intf * intf, uint8_t cipher_suite_id)
+ipmi_intf_session_set_cipher_suite_id(struct ipmi_intf * intf,
+		enum cipher_suite_ids cipher_suite_id)
 {
 	intf->ssn_params.cipher_suite_id = cipher_suite_id;
 }
+#endif /* IPMI_INTF_LANPLUS */
 
 void
 ipmi_intf_session_set_sol_escape_char(struct ipmi_intf * intf, char sol_escape_char)

--- a/src/plugins/ipmi_intf.c
+++ b/src/plugins/ipmi_intf.c
@@ -252,7 +252,7 @@ ipmi_intf_session_set_lookupbit(struct ipmi_intf * intf, uint8_t lookupbit)
 #ifdef IPMI_INTF_LANPLUS
 void
 ipmi_intf_session_set_cipher_suite_id(struct ipmi_intf * intf,
-		enum cipher_suite_ids cipher_suite_id)
+                                      enum cipher_suite_ids cipher_suite_id)
 {
 	intf->ssn_params.cipher_suite_id = cipher_suite_id;
 }

--- a/src/plugins/lanplus/lanplus.c
+++ b/src/plugins/lanplus/lanplus.c
@@ -163,114 +163,109 @@ extern int verbose;
  * returns 0 on success
  *         1 on failure
  */
-int lanplus_get_requested_ciphers(int       cipher_suite_id,
+int lanplus_get_requested_ciphers(enum cipher_suite_ids cipher_suite_id,
 								  uint8_t * auth_alg,
 								  uint8_t * integrity_alg,
 								  uint8_t * crypt_alg)
 {
-#ifdef HAVE_CRYPTO_SHA256
-	if ((cipher_suite_id < 0) || (cipher_suite_id > 17)) {
-		return 1;
-	}
-#else
-	if ((cipher_suite_id < 0) || (cipher_suite_id > 14))
-		return 1;
-#endif /* HAVE_CRYPTO_SHA256 */
 		/* See table 22-19 for the source of the statement */
 	switch (cipher_suite_id)
 	{
-	case 0:
+	case IPMI_LANPLUS_CIPHER_SUITE_0:
 		*auth_alg      = IPMI_AUTH_RAKP_NONE;
 		*integrity_alg = IPMI_INTEGRITY_NONE;
 		*crypt_alg     = IPMI_CRYPT_NONE;
 		break;
-	case 1:
+	case IPMI_LANPLUS_CIPHER_SUITE_1:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_SHA1;
 		*integrity_alg = IPMI_INTEGRITY_NONE;
 		*crypt_alg     = IPMI_CRYPT_NONE;
 		break;
-	case 2:
+	case IPMI_LANPLUS_CIPHER_SUITE_2:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_SHA1;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_SHA1_96;
 		*crypt_alg     = IPMI_CRYPT_NONE;
 		break;
-	case 3:
+	case IPMI_LANPLUS_CIPHER_SUITE_3:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_SHA1;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_SHA1_96;
 		*crypt_alg     = IPMI_CRYPT_AES_CBC_128;
 		break;
-	case 4:
+	case IPMI_LANPLUS_CIPHER_SUITE_4:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_SHA1;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_SHA1_96;
 		*crypt_alg     = IPMI_CRYPT_XRC4_128;
 		break;
-	case 5:
+	case IPMI_LANPLUS_CIPHER_SUITE_5:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_SHA1;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_SHA1_96;
 		*crypt_alg     = IPMI_CRYPT_XRC4_40;
 		break;
-	case 6:
+	case IPMI_LANPLUS_CIPHER_SUITE_6:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_MD5;
 		*integrity_alg = IPMI_INTEGRITY_NONE;
 		*crypt_alg     = IPMI_CRYPT_NONE;
 		break;
-	case 7:
+	case IPMI_LANPLUS_CIPHER_SUITE_7:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_MD5;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_MD5_128;
 		*crypt_alg     = IPMI_CRYPT_NONE;
 		break;
-	case 8:
+	case IPMI_LANPLUS_CIPHER_SUITE_8:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_MD5;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_MD5_128;
 		*crypt_alg     = IPMI_CRYPT_AES_CBC_128;
 		break;
-	case 9:
+	case IPMI_LANPLUS_CIPHER_SUITE_9:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_MD5;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_MD5_128;
 		*crypt_alg     = IPMI_CRYPT_XRC4_128;
 		break;
-	case 10:
+	case IPMI_LANPLUS_CIPHER_SUITE_10:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_MD5;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_MD5_128;
 		*crypt_alg     = IPMI_CRYPT_XRC4_40;
 		break;
-	case 11:
+	case IPMI_LANPLUS_CIPHER_SUITE_11:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_MD5;
 		*integrity_alg = IPMI_INTEGRITY_MD5_128;
 		*crypt_alg     = IPMI_CRYPT_NONE;
 		break;
-	case 12:
+	case IPMI_LANPLUS_CIPHER_SUITE_12:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_MD5;
 		*integrity_alg = IPMI_INTEGRITY_MD5_128;
 		*crypt_alg     = IPMI_CRYPT_AES_CBC_128;
 		break;
-	case 13:
+	case IPMI_LANPLUS_CIPHER_SUITE_13:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_MD5;
 		*integrity_alg = IPMI_INTEGRITY_MD5_128;
 		*crypt_alg     = IPMI_CRYPT_XRC4_128;
 		break;
-	case 14:
+	case IPMI_LANPLUS_CIPHER_SUITE_14:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_MD5;
 		*integrity_alg = IPMI_INTEGRITY_MD5_128;
 		*crypt_alg     = IPMI_CRYPT_XRC4_40;
 		break;
 #ifdef HAVE_CRYPTO_SHA256
-	case 15:
+	case IPMI_LANPLUS_CIPHER_SUITE_15:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_SHA256;
 		*integrity_alg = IPMI_INTEGRITY_NONE;
 		*crypt_alg     = IPMI_CRYPT_NONE;
 		break;
-	case 16:
+	case IPMI_LANPLUS_CIPHER_SUITE_16:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_SHA256;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_SHA256_128;
 		*crypt_alg     = IPMI_CRYPT_NONE;
 		break;
-	case 17:
+	case IPMI_LANPLUS_CIPHER_SUITE_17:
 		*auth_alg      = IPMI_AUTH_RAKP_HMAC_SHA256;
 		*integrity_alg = IPMI_INTEGRITY_HMAC_SHA256_128;
 		*crypt_alg     = IPMI_CRYPT_AES_CBC_128;
 		break;
 #endif /* HAVE_CRYPTO_SHA256 */
+	case IPMI_LANPLUS_CIPHER_SUITE_RESERVED:
+	default:
+		return 1;
 	}
 
 	return 0;
@@ -3381,6 +3376,57 @@ ipmi_set_session_privlvl_cmd(struct ipmi_intf * intf)
 	return 0;
 }
 
+static uint8_t
+ipmi_find_best_cipher_suite(struct ipmi_intf *intf)
+{
+	enum cipher_suite_ids best_suite = IPMI_LANPLUS_CIPHER_SUITE_RESERVED;
+#ifdef HAVE_CRYPTO_SHA256
+	struct cipher_suite_info suites[MAX_CIPHER_SUITE_COUNT];
+	size_t nr_suites = ARRAY_SIZE(suites);
+	/* cipher suite best order is chosen with this criteria:
+	 * HMAC-MD5 and MD5 are BAD; xRC4 is bad; AES128 is required
+	 * HMAC-SHA256 > HMAC-SHA1
+	 * secure authentication > encrypted content
+	 *
+	 * With xRC4 out, all cipher suites with MD5 out, and cipher suite 3 being
+	 * required by the spec, the only better defined standard cipher suite is
+	 * 17. So if SHA256 is available, we should try to use that, otherwise,
+	 * fall back to 3.
+	 */
+	const enum cipher_suite_ids cipher_order_preferred[] = {
+		IPMI_LANPLUS_CIPHER_SUITE_17,
+		IPMI_LANPLUS_CIPHER_SUITE_3,
+	};
+	const size_t nr_preferred = ARRAY_SIZE(cipher_order_preferred);
+	size_t ipref, i;
+
+	if (ipmi_get_channel_cipher_suites(intf, "ipmi", IPMI_LAN_CHANNEL_E,
+	                                   suites, &nr_suites) < 0)
+	{
+		/* default legacy behavior - cipher suite 3 if none is requested */
+		return IPMI_LANPLUS_CIPHER_SUITE_3;
+	}
+	for (ipref = 0; ipref < nr_preferred &&
+	                IPMI_LANPLUS_CIPHER_SUITE_RESERVED == best_suite; ipref++)
+	{
+		for (i = 0; i < nr_suites; i++) {
+			if (cipher_order_preferred[ipref] == suites[i].cipher_suite_id) {
+				best_suite = cipher_order_preferred[ipref];
+				break;
+			}
+		}
+	}
+#endif /* HAVE_CRYPTO_SHA256 */
+	if (IPMI_LANPLUS_CIPHER_SUITE_RESERVED == best_suite) {
+		/* IPMI 2.0 spec requires that cipher suite 3 is implemented
+		 * so we should always be able to fall back to that if better
+		 * options are not available. */
+		best_suite = IPMI_LANPLUS_CIPHER_SUITE_3;
+	}
+	lprintf(LOG_INFO, "Using best available cipher suite %d\n", best_suite);
+	return best_suite;
+}
+
 /**
  * ipmi_lanplus_open
  */
@@ -3453,6 +3499,16 @@ ipmi_lanplus_open(struct ipmi_intf * intf)
 	if (!ipmi_oem_active(intf, "i82571spt") && ! auth_cap.v20_data_available) {
 		lprintf(LOG_INFO, "This BMC does not support IPMI v2 / RMCP+");
 		goto fail;
+	}
+	/*
+	 * If no cipher suite was provided, query the channel cipher suite list and
+	 * pick the best one available
+	 */
+	if (IPMI_LANPLUS_CIPHER_SUITE_RESERVED ==
+	    intf->ssn_params.cipher_suite_id)
+	{
+		ipmi_intf_session_set_cipher_suite_id(intf,
+			ipmi_find_best_cipher_suite(intf));
 	}
 
 	/*
@@ -3666,7 +3722,7 @@ static int ipmi_lanplus_setup(struct ipmi_intf * intf)
 
 static void ipmi_lanp_set_max_rq_data_size(struct ipmi_intf * intf, uint16_t size)
 {
-	if (intf->ssn_params.cipher_suite_id == 3) {
+	if (intf->ssn_params.cipher_suite_id == IPMI_LANPLUS_CIPHER_SUITE_3) {
 		/*
 		 * encrypted payload can only be multiple of 16 bytes
 		 */
@@ -3684,7 +3740,7 @@ static void ipmi_lanp_set_max_rq_data_size(struct ipmi_intf * intf, uint16_t siz
 
 static void ipmi_lanp_set_max_rp_data_size(struct ipmi_intf * intf, uint16_t size)
 {
-	if (intf->ssn_params.cipher_suite_id == 3) {
+	if (intf->ssn_params.cipher_suite_id == IPMI_LANPLUS_CIPHER_SUITE_3) {
 		/*
 		 * encrypted payload can only be multiple of 16 bytes
 		 */


### PR DESCRIPTION
Based on current crypto alogrithms, one could rank cipher suites along
these lines:

17 > 3 >> all the rest

17 and 3 are the only cipher suites that implement any sort of
confidentiality alogorithm that is secure. In addition, any hmac-md5 or
md5 integrity algorithm used in integrity is weak at best and dangerous
for authentication.

This could possibly be enabled in a simpler mechanism by simply checking
for 17 and then choosing it before falling back to 3, but the way this
is implemented, it makes it easy to change the list of acceptable
algorithms from two to three or more items.

Signed-off-by: Vernon Mauery <vernon.mauery@intel.com>