### PR TITLE
exchange-bmc-os-info: Remove dependency on ipmi.service

### DIFF
--- a/contrib/exchange-bmc-os-info.service.redhat
+++ b/contrib/exchange-bmc-os-info.service.redhat
@@ -1,7 +1,7 @@
 [Unit]
 Description=Exchange Information between BMC and OS
-After=ipmi.service network.target
-Requires=ipmi.service
+ConditionFileIsExecutable=/usr/bin/ipmitool
+ConditionPathExistsGlob=/dev/ipmi*
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Most modern systems do not require ipmi.service to load the kernel
modules. Checking for /dev/ipmi* would be sufficient.

Signed-off-by: Charles Rose <charles.rose@dell.com>