### PR TITLE
Correct segment violation in memmove when DCMI request returns C6.

### DIFF
--- a/src/plugins/lanplus/lanplus.c
+++ b/src/plugins/lanplus/lanplus.c
@@ -792,7 +792,7 @@ ipmi_lan_poll_single(struct ipmi_intf * intf)
 			 * rsp->data_len becomes the length of that data
 			 */
 			extra_data_length = payload_size - (offset - payload_start) - 1;
-			if (extra_data_length) {
+			if (extra_data_length > 0) {
 				rsp->data_len = extra_data_length;
 				memmove(rsp->data, rsp->data + offset, extra_data_length);
 			} else {
@@ -846,7 +846,7 @@ ipmi_lan_poll_single(struct ipmi_intf * intf)
 		}
 		read_sol_packet(rsp, &offset);
 		extra_data_length = payload_size - (offset - payload_start);
-		if (rsp && extra_data_length) {
+		if (rsp && extra_data_length > 0) {
 			rsp->data_len = extra_data_length;
 			memmove(rsp->data, rsp->data + offset, extra_data_length);
 		} else {


### PR DESCRIPTION
On occasion a dcmi power reading will return error C6, and the decrypted payload is shorter than the expected length. The lanplus_decrypt_aes_cbc_128() adjusts the payload_size downward by one byte. In ipmi_lan_poll_single() a calculation to determine if the payload size has increased  results in the extra_data_length becoming -1, with a subsequent segv when calling a memmove to shift response data. The fix is to check for a positive value in the extra_data_length. The IPMI_PAYLOAD_TYPE_SOL further down the function has a similar fix, checking for a positive extra_data_length before calling the memmove..