### PR TITLE
Cleanup compiler warnings

### DIFF
--- a/include/ipmitool/ipmi_sdr.h
+++ b/include/ipmitool/ipmi_sdr.h
@@ -864,11 +864,10 @@ struct sdr_get_rs *ipmi_sdr_get_next_header(struct ipmi_intf *intf,
 					    struct ipmi_sdr_iterator *i);
 uint8_t *ipmi_sdr_get_record(struct ipmi_intf *intf, struct sdr_get_rs *header,
 			     struct ipmi_sdr_iterator *i);
-void ipmi_sdr_end(struct ipmi_intf *intf, struct ipmi_sdr_iterator *i);
+void ipmi_sdr_end(struct ipmi_sdr_iterator *i);
 int ipmi_sdr_print_sdr(struct ipmi_intf *intf, uint8_t type);
 
-int ipmi_sdr_print_name_from_rawentry(struct ipmi_intf *intf,uint16_t id,
-                                      uint8_t type,uint8_t * raw);
+int ipmi_sdr_print_name_from_rawentry(uint16_t id, uint8_t type,uint8_t * raw);
 int ipmi_sdr_print_rawentry(struct ipmi_intf *intf, uint8_t type, uint8_t * raw,
 			    int len);
 int ipmi_sdr_print_listentry(struct ipmi_intf *intf,
@@ -912,15 +911,9 @@ int ipmi_sdr_get_reservation(struct ipmi_intf *intf, int use_builtin,
 
 int ipmi_sdr_print_sensor_eventonly(struct ipmi_intf *intf,
 				    struct sdr_record_eventonly_sensor *sensor);
-int ipmi_sdr_print_sensor_generic_locator(struct ipmi_intf *intf,
-					  struct sdr_record_generic_locator
-					  *fru);
-int ipmi_sdr_print_sensor_fru_locator(struct ipmi_intf *intf,
-				      struct sdr_record_fru_locator *fru);
-int ipmi_sdr_print_sensor_mc_locator(struct ipmi_intf *intf,
-				     struct sdr_record_mc_locator *mc);
-int ipmi_sdr_print_sensor_entity_assoc(struct ipmi_intf *intf,
-				       struct sdr_record_entity_assoc *assoc);
+int ipmi_sdr_print_sensor_generic_locator(struct sdr_record_generic_locator *fru);
+int ipmi_sdr_print_sensor_fru_locator(struct sdr_record_fru_locator *fru);
+int ipmi_sdr_print_sensor_mc_locator(struct sdr_record_mc_locator *mc);
 
 struct sdr_record_list *ipmi_sdr_find_sdr_byentity(struct ipmi_intf *intf,
 						   struct entity_id *entity);
@@ -933,8 +926,8 @@ struct sdr_record_list *ipmi_sdr_find_sdr_byid(struct ipmi_intf *intf,
 struct sdr_record_list *ipmi_sdr_find_sdr_bytype(struct ipmi_intf *intf,
 						 uint8_t type);
 int ipmi_sdr_list_cache(struct ipmi_intf *intf);
-int ipmi_sdr_list_cache_fromfile(struct ipmi_intf *intf, const char *ifile);
-void ipmi_sdr_list_empty(struct ipmi_intf *intf);
+int ipmi_sdr_list_cache_fromfile(const char *ifile);
+void ipmi_sdr_list_empty(void);
 int ipmi_sdr_print_info(struct ipmi_intf *intf);
 void ipmi_sdr_print_discrete_state(struct ipmi_intf *intf,
 				const char *desc, uint8_t sensor_type,

--- a/lib/ipmi_dcmi.c
+++ b/lib/ipmi_dcmi.c
@@ -3970,14 +3970,14 @@ ipmi_print_sensor_info(struct ipmi_intf *intf, uint16_t rec_id)
 	}
 	if (!header) {
 		lprintf(LOG_DEBUG, "header == NULL");
-		ipmi_sdr_end(intf, itr);
+		ipmi_sdr_end(itr);
 		return (-1);
 	}
 	/* yes, we found the SDR for this record ID, now get full record */
 	rec = ipmi_sdr_get_record(intf, header, itr);
 	if (!rec) {
 		lprintf(LOG_DEBUG, "rec == NULL");
-		ipmi_sdr_end(intf, itr);
+		ipmi_sdr_end(itr);
 		return (-1);
 	}
 	if ((header->type == SDR_RECORD_TYPE_FULL_SENSOR) ||
@@ -3990,6 +3990,6 @@ ipmi_print_sensor_info(struct ipmi_intf *intf, uint16_t rec_id)
 	}
 	free(rec);
 	rec = NULL;
-	ipmi_sdr_end(intf, itr);
+	ipmi_sdr_end(itr);
 	return rc;
 }

--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -3186,7 +3186,7 @@ ipmi_fru_print_all(struct ipmi_intf * intf)
 		fru = NULL;
 	}
 
-	ipmi_sdr_end(intf, itr);
+	ipmi_sdr_end(itr);
 
 	return rc;
 }

--- a/lib/ipmi_main.c
+++ b/lib/ipmi_main.c
@@ -984,7 +984,7 @@ ipmi_main(int argc, char ** argv,
 
 	/* parse local SDR cache if given */
 	if (sdrcache) {
-		ipmi_sdr_list_cache_fromfile(ipmi_main_intf, sdrcache);
+		ipmi_sdr_list_cache_fromfile(sdrcache);
 	}
 	/* Parse SEL OEM file if given */
 	if (seloem) {

--- a/lib/ipmi_sdr.c
+++ b/lib/ipmi_sdr.c
@@ -2119,15 +2119,13 @@ ipmi_sdr_print_sensor_eventonly(struct ipmi_intf *intf,
 
 /* ipmi_sdr_print_sensor_mc_locator  -  print SDR MC locator record
  *
- * @intf:	ipmi interface
  * @mc:		mc locator sdr record
  *
  * returns 0 on success
  * returns -1 on error
  */
 int
-ipmi_sdr_print_sensor_mc_locator(struct ipmi_intf *intf,
-				 struct sdr_record_mc_locator *mc)
+ipmi_sdr_print_sensor_mc_locator(struct sdr_record_mc_locator *mc)
 {
 	char desc[17];
 
@@ -2215,15 +2213,13 @@ ipmi_sdr_print_sensor_mc_locator(struct ipmi_intf *intf,
 
 /* ipmi_sdr_print_sensor_generic_locator  -  print generic device locator record
  *
- * @intf:	ipmi interface
  * @gen:	generic device locator sdr record
  *
  * returns 0 on success
  * returns -1 on error
  */
 int
-ipmi_sdr_print_sensor_generic_locator(struct ipmi_intf *intf,
-				      struct sdr_record_generic_locator *dev)
+ipmi_sdr_print_sensor_generic_locator(struct sdr_record_generic_locator *dev)
 {
 	char desc[17];
 
@@ -2272,15 +2268,13 @@ ipmi_sdr_print_sensor_generic_locator(struct ipmi_intf *intf,
 
 /* ipmi_sdr_print_sensor_fru_locator  -  print FRU locator record
  *
- * @intf:	ipmi interface
  * @fru:	fru locator sdr record
  *
  * returns 0 on success
  * returns -1 on error
  */
 int
-ipmi_sdr_print_sensor_fru_locator(struct ipmi_intf *intf,
-				  struct sdr_record_fru_locator *fru)
+ipmi_sdr_print_sensor_fru_locator(struct sdr_record_fru_locator *fru)
 {
 	char desc[17];
 
@@ -2329,32 +2323,15 @@ ipmi_sdr_print_sensor_fru_locator(struct ipmi_intf *intf,
 	return 0;
 }
 
-/* ipmi_sdr_print_sensor_entity_assoc  -  print SDR entity association record
- *
- * @intf:	ipmi interface
- * @mc:		entity association sdr record
- *
- * returns 0 on success
- * returns -1 on error
- */
-int
-ipmi_sdr_print_sensor_entity_assoc(struct ipmi_intf *intf,
-				   struct sdr_record_entity_assoc *assoc)
-{
-	return 0;
-}
-
 /* ipmi_sdr_print_sensor_oem_intel  -  print Intel OEM sensors
  *
- * @intf:	ipmi interface
  * @oem:	oem sdr record
  *
  * returns 0 on success
  * returns -1 on error
  */
 static int
-ipmi_sdr_print_sensor_oem_intel(struct ipmi_intf *intf,
-				struct sdr_record_oem *oem)
+ipmi_sdr_print_sensor_oem_intel(struct sdr_record_oem *oem)
 {
 	switch (oem->data[3]) {	/* record sub-type */
 	case 0x02:		/* Power Unit Map */
@@ -2435,14 +2412,13 @@ ipmi_sdr_print_sensor_oem_intel(struct ipmi_intf *intf,
  * a particular BMC might stuff into its OEM records.  The
  * records are keyed off manufacturer ID and record subtypes.
  *
- * @intf:	ipmi interface
  * @oem:	oem sdr record
  *
  * returns 0 on success
  * returns -1 on error
  */
 static int
-ipmi_sdr_print_sensor_oem(struct ipmi_intf *intf, struct sdr_record_oem *oem)
+ipmi_sdr_print_sensor_oem(struct sdr_record_oem *oem)
 {
 	int rc = 0;
 
@@ -2457,7 +2433,7 @@ ipmi_sdr_print_sensor_oem(struct ipmi_intf *intf, struct sdr_record_oem *oem)
 	/* intel manufacturer id */
 	if (oem->data[0] == 0x57 &&
 	    oem->data[1] == 0x01 && oem->data[2] == 0x00) {
-		rc = ipmi_sdr_print_sensor_oem_intel(intf, oem);
+		rc = ipmi_sdr_print_sensor_oem_intel(oem);
 	}
 
 	return rc;
@@ -2465,7 +2441,6 @@ ipmi_sdr_print_sensor_oem(struct ipmi_intf *intf, struct sdr_record_oem *oem)
 
 /* ipmi_sdr_print_name_from_rawentry  -  Print SDR name  from raw data
  *
- * @intf:	ipmi interface
  * @type:	sensor type
  * @raw:	raw sensor data
  *
@@ -2473,7 +2448,7 @@ ipmi_sdr_print_sensor_oem(struct ipmi_intf *intf, struct sdr_record_oem *oem)
  * returns -1 on error
  */
 int
-ipmi_sdr_print_name_from_rawentry(struct ipmi_intf *intf, uint16_t id,
+ipmi_sdr_print_name_from_rawentry(uint16_t id,
                                   uint8_t type, uint8_t *raw)
 {
    union {
@@ -2551,35 +2526,27 @@ ipmi_sdr_print_rawentry(struct ipmi_intf *intf, uint8_t type,
 						      *) raw);
 		break;
 	case SDR_RECORD_TYPE_GENERIC_DEVICE_LOCATOR:
-		rc = ipmi_sdr_print_sensor_generic_locator(intf,
-							   (struct
+		rc = ipmi_sdr_print_sensor_generic_locator((struct
 							    sdr_record_generic_locator
 							    *) raw);
 		break;
 	case SDR_RECORD_TYPE_FRU_DEVICE_LOCATOR:
-		rc = ipmi_sdr_print_sensor_fru_locator(intf,
-						       (struct
+		rc = ipmi_sdr_print_sensor_fru_locator((struct
 							sdr_record_fru_locator
 							*) raw);
 		break;
 	case SDR_RECORD_TYPE_MC_DEVICE_LOCATOR:
-		rc = ipmi_sdr_print_sensor_mc_locator(intf,
-						      (struct
+		rc = ipmi_sdr_print_sensor_mc_locator((struct
 						       sdr_record_mc_locator *)
 						      raw);
 		break;
 	case SDR_RECORD_TYPE_ENTITY_ASSOC:
-		rc = ipmi_sdr_print_sensor_entity_assoc(intf,
-							(struct
-							 sdr_record_entity_assoc
-							 *) raw);
 		break;
 	case SDR_RECORD_TYPE_OEM:{
 			struct sdr_record_oem oem;
 			oem.data = raw;
 			oem.data_len = len;
-			rc = ipmi_sdr_print_sensor_oem(intf,
-						       (struct sdr_record_oem *)
+			rc = ipmi_sdr_print_sensor_oem((struct sdr_record_oem *)
 						       &oem);
 			break;
 		}
@@ -2616,24 +2583,19 @@ ipmi_sdr_print_listentry(struct ipmi_intf *intf, struct sdr_record_list *entry)
 						     entry->record.eventonly);
 		break;
 	case SDR_RECORD_TYPE_GENERIC_DEVICE_LOCATOR:
-		rc = ipmi_sdr_print_sensor_generic_locator(intf,
-							   entry->record.
+		rc = ipmi_sdr_print_sensor_generic_locator(entry->record.
 							   genloc);
 		break;
 	case SDR_RECORD_TYPE_FRU_DEVICE_LOCATOR:
-		rc = ipmi_sdr_print_sensor_fru_locator(intf,
-						       entry->record.fruloc);
+		rc = ipmi_sdr_print_sensor_fru_locator(entry->record.fruloc);
 		break;
 	case SDR_RECORD_TYPE_MC_DEVICE_LOCATOR:
-		rc = ipmi_sdr_print_sensor_mc_locator(intf,
-						      entry->record.mcloc);
+		rc = ipmi_sdr_print_sensor_mc_locator(entry->record.mcloc);
 		break;
 	case SDR_RECORD_TYPE_ENTITY_ASSOC:
-		rc = ipmi_sdr_print_sensor_entity_assoc(intf,
-							entry->record.entassoc);
 		break;
 	case SDR_RECORD_TYPE_OEM:
-		rc = ipmi_sdr_print_sensor_oem(intf, entry->record.oem);
+		rc = ipmi_sdr_print_sensor_oem(entry->record.oem);
 		break;
 	case SDR_RECORD_TYPE_DEVICE_ENTITY_ASSOC:
 	case SDR_RECORD_TYPE_MC_CONFIRMATION:
@@ -3070,13 +3032,12 @@ ipmi_sdr_get_record(struct ipmi_intf * intf, struct sdr_get_rs * header,
 
 /* ipmi_sdr_end  -  cleanup SDR iterator
  *
- * @intf:	ipmi interface
  * @itr:	SDR iterator
  *
  * no meaningful return code
  */
 void
-ipmi_sdr_end(struct ipmi_intf *intf, struct ipmi_sdr_iterator *itr)
+ipmi_sdr_end(struct ipmi_sdr_iterator *itr)
 {
 	if (itr) {
 		free(itr);
@@ -3137,16 +3098,14 @@ __sdr_list_empty(struct sdr_record_list *head)
 
 /* ipmi_sdr_list_empty  -  clean global SDR list
  *
- * @intf:	ipmi interface
- *
  * no meaningful return code
  */
 void
-ipmi_sdr_list_empty(struct ipmi_intf *intf)
+ipmi_sdr_list_empty(void)
 {
 	struct sdr_record_list *list, *next;
 
-	ipmi_sdr_end(intf, sdr_list_itr);
+	ipmi_sdr_end(sdr_list_itr);
 
 	for (list = sdr_list_head; list; list = next) {
 		switch (list->type) {
@@ -3915,14 +3874,13 @@ ipmi_sdr_find_sdr_byid(struct ipmi_intf *intf, char *id)
 
 /* ipmi_sdr_list_cache_fromfile  -  generate SDR cache for fast lookup from local file
  *
- * @intf:	ipmi interface
  * @ifile:	input filename
  *
  * returns pointer to SDR list
  * returns NULL on error
  */
 int
-ipmi_sdr_list_cache_fromfile(struct ipmi_intf *intf, const char *ifile)
+ipmi_sdr_list_cache_fromfile(const char *ifile)
 {
 	FILE *fp;
 	struct __sdr_header {
@@ -4376,7 +4334,7 @@ ipmi_sdr_dump_bin(struct ipmi_intf *intf, const char *ofile)
 		sdr_list_tail = sdrr;
 	}
 
-	ipmi_sdr_end(intf, itr);
+	ipmi_sdr_end(itr);
 
 	/* now write to file */
 	fp = ipmi_open_file_write(ofile);

--- a/lib/ipmi_sdr.c
+++ b/lib/ipmi_sdr.c
@@ -205,7 +205,7 @@ sdr_convert_sensor_reading(struct sdr_record_full_sensor *sensor, uint8_t val)
 	case 1:
 		if (val & 0x80)
 			val++;
-		/* Deliberately fall through to case 2. */
+		/* fall through */
 	case 2:
 		result = (double) (((m * (int8_t) val) +
 				    (b * pow(10, k1))) * pow(10, k2));
@@ -285,7 +285,7 @@ sdr_convert_sensor_hysterisis(struct sdr_record_full_sensor *sensor, uint8_t val
 	case 1:
 		if (val & 0x80)
 			val++;
-		/* Deliberately fall through to case 2. */
+		/* fall through */
 	case 2:
 		result = (double) (((m * (int8_t) val) ) * pow(10, k2));
 		break;
@@ -360,7 +360,7 @@ sdr_convert_sensor_tolerance(struct sdr_record_full_sensor *sensor, uint8_t val)
 	case 1:
 		if (val & 0x80)
 			val++;
-		/* Deliberately fall through to case 2. */
+		/* fall through */
 	case 2:
 		result = (double) (((m * ((double)((int8_t) val)/2))) * pow(10, k2));
 		break;

--- a/lib/ipmi_sdradd.c
+++ b/lib/ipmi_sdradd.c
@@ -263,7 +263,7 @@ sdrr_get_records(struct ipmi_intf *intf, struct ipmi_sdr_iterator *itr,
     sdrr->type = header->type;
     sdrr->length = header->length;
     sdrr->raw = ipmi_sdr_get_record(intf, header, itr);
-    (void)ipmi_sdr_print_name_from_rawentry(intf,  sdrr->id, sdrr->type,sdrr->raw);
+    (void)ipmi_sdr_print_name_from_rawentry(sdrr->id, sdrr->type,sdrr->raw);
 
     /* put in the record queue */
     if (!queue->head)
@@ -295,7 +295,7 @@ sdr_copy_to_sdrr(struct ipmi_intf *intf, int use_builtin,
 
   printf("Load SDRs from 0x%x\n", from_addr);
   rc = sdrr_get_records(intf, itr, &sdrr_queue);
-  ipmi_sdr_end(intf, itr);
+  ipmi_sdr_end(itr);
   /* ... */
 
   /* write the SDRs to the destination SDR Repository */

--- a/lib/ipmi_sensor.c
+++ b/lib/ipmi_sensor.c
@@ -532,7 +532,7 @@ ipmi_sensor_list(struct ipmi_intf *intf)
 		/* rc = (r == 0) ? rc : r; */
 	}
 
-	ipmi_sdr_end(intf, itr);
+	ipmi_sdr_end(itr);
 
 	return rc;
 }

--- a/src/plugins/ipmi_intf.c
+++ b/src/plugins/ipmi_intf.c
@@ -314,7 +314,7 @@ ipmi_intf_session_cleanup(struct ipmi_intf *intf)
 void
 ipmi_cleanup(struct ipmi_intf * intf)
 {
-	ipmi_sdr_list_empty(intf);
+	ipmi_sdr_list_empty();
 	ipmi_intf_session_set_hostname(intf, NULL);
 }
 


### PR DESCRIPTION
I really don't like seeing so many compiler warnings when ipmitool builds. This is the first round of removing a few of them.