### PR TITLE
bugfix: ipmi_fru: fixup array bounds checking

### DIFF
--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -3758,29 +3758,30 @@ ipmi_fru_get_multirec(struct ipmi_intf * intf, uint8_t id ,
 }
 
 static int
-ipmi_fru_upg_ekeying(struct ipmi_intf * intf,
-			char * pFileName,
-			uint8_t fruId)
+ipmi_fru_upg_ekeying(struct ipmi_intf *intf,
+		     char *pFileName,
+		     uint8_t fruId)
 {
 	struct fru_info fruInfo = {0};
-	uint8_t *buf = NULL;
+	uint8_t *buf;
 	uint32_t offFruMultiRec = 0;
 	uint32_t fruMultiRecSize = 0;
 	uint32_t offFileMultiRec = 0;
 	uint32_t fileMultiRecSize = 0;
+
 	if (!pFileName) {
 		lprintf(LOG_ERR, "File expected, but none given.");
 		return (-1);
 	}
 	if (ipmi_fru_get_multirec_location_from_fru(intf, fruId, &fruInfo,
-							&offFruMultiRec, &fruMultiRecSize) != 0) {
+			&offFruMultiRec, &fruMultiRecSize) != 0) {
 		lprintf(LOG_ERR, "Failed to get multirec location from FRU.");
 		return (-1);
 	}
 	lprintf(LOG_DEBUG, "FRU Size        : %lu\n", fruMultiRecSize);
 	lprintf(LOG_DEBUG, "Multi Rec offset: %lu\n", offFruMultiRec);
 	if (ipmi_fru_get_multirec_size_from_file(pFileName, &fileMultiRecSize,
-				&offFileMultiRec) != 0) {
+			&offFileMultiRec) != 0) {
 		lprintf(LOG_ERR, "Failed to get multirec size from file '%s'.", pFileName);
 		return (-1);
 	}
@@ -3790,35 +3791,24 @@ ipmi_fru_upg_ekeying(struct ipmi_intf * intf,
 		return (-1);
 	}
 	if (ipmi_fru_get_multirec_from_file(pFileName, buf, fileMultiRecSize,
-				offFileMultiRec) != 0) {
+			offFileMultiRec) != 0) {
 		lprintf(LOG_ERR, "Failed to get multirec from file '%s'.", pFileName);
-		if (buf) {
-			free(buf);
-			buf = NULL;
-		}
+		free(buf);
 		return (-1);
 	}
 	if (ipmi_fru_get_adjust_size_from_buffer(buf, &fileMultiRecSize) != 0) {
 		lprintf(LOG_ERR, "Failed to adjust size from buffer.");
-		if (buf) {
-			free(buf);
-			buf = NULL;
-		}
+		free(buf);
 		return (-1);
 	}
 	if (write_fru_area(intf, &fruInfo, fruId, 0, offFruMultiRec,
-				fileMultiRecSize, buf) != 0) {
+			   fileMultiRecSize, buf) != 0) {
 		lprintf(LOG_ERR, "Failed to write FRU area.");
-		if (buf) {
-			free(buf);
-			buf = NULL;
-		}
+		free(buf);
 		return (-1);
 	}
-	if (buf) {
-		free(buf);
-		buf = NULL;
-	}
+
+	free(buf);
 	lprintf(LOG_INFO, "Done upgrading Ekey.");
 	return 0;
 }

--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -1654,7 +1654,6 @@ static void ipmi_fru_oemkontron_get(int argc,
 	uint8_t blockCount;
 	uint8_t blockIndex = 0;
 
-	unsigned int matchInstance = 0;
 	uint8_t instance = 0;
 
 	if (str2uchar(argv[OEM_KONTRON_INSTANCE_ARG_POS], &instance) != 0) {
@@ -1696,7 +1695,6 @@ static void ipmi_fru_oemkontron_get(int argc,
 			       OEM_KONTRON_FIELD_SIZE,
 			       OEM_KONTRON_FIELD_SIZE,
 			       ((tOemKontronInformationRecordV0 *) pRecordData)->crc32);
-			matchInstance++;
 			offset += sizeof(tOemKontronInformationRecordV0);
 			offset++;
 		} else if (version == 1) {
@@ -1716,7 +1714,6 @@ static void ipmi_fru_oemkontron_get(int argc,
 			       OEM_KONTRON_FIELD_SIZE,
 			       OEM_KONTRON_FIELD_SIZE,
 			       ((tOemKontronInformationRecordV1 *) pRecordData)->crc32);
-			matchInstance++;
 			offset += sizeof(tOemKontronInformationRecordV1);
 			offset++;
 		} else {

--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -1000,8 +1000,7 @@ fru_area_print_chassis(struct ipmi_intf * intf, struct fru_info * fru,
 	}
 
 	/* read any extra fields */
-	while ((fru_data[i] != 0xc1) && (i < fru_len))
-	{
+	while ((i < fru_len) && (fru_data[i] != 0xc1)) {
 		int j = i;
 		fru_area = get_fru_area_str(fru_data, &i);
 		if (fru_area) {
@@ -1124,8 +1123,7 @@ fru_area_print_board(struct ipmi_intf * intf, struct fru_info * fru,
 	}
 
 	/* read any extra fields */
-	while ((fru_data[i] != 0xc1) && (i < fru_len))
-	{
+	while ((i < fru_len) && (fru_data[i] != 0xc1)) {
 		int j = i;
 		fru_area = get_fru_area_str(fru_data, &i);
 		if (fru_area) {
@@ -1259,8 +1257,7 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 	}
 
 	/* read any extra fields */
-	while ((fru_data[i] != 0xc1) && (i < fru_len))
-	{
+	while ((i < fru_len) && (fru_data[i] != 0xc1)) {
 		int j = i;
 		fru_area = get_fru_area_str(fru_data, &i);
 		if (fru_area) {


### PR DESCRIPTION
Fixup the following array bounds checking bugs:
[lib/ipmi_fru.c:1003]: (style) Array index 'i' is
used before limits check.
[lib/ipmi_fru.c:1127]: (style) Array index 'i' is
used before limits check.
[lib/ipmi_fru.c:1262]: (style) Array index 'i' is
used before limits check.

Signed-off-by: Patrick Venture <venture@google.com>