### PR TITLE
cleanup: lanplus: remove unused assignment

### DIFF
--- a/src/plugins/lan/lan.c
+++ b/src/plugins/lan/lan.c
@@ -1869,7 +1869,7 @@ ipmi_lan_activate_session(struct ipmi_intf * intf)
 }
 
 void
-ipmi_lan_close(struct ipmi_intf * intf)
+ipmi_lan_close(struct ipmi_intf *intf)
 {
 	if (!intf->abort && intf->session)
 		ipmi_close_session_cmd(intf);
@@ -1883,7 +1883,6 @@ ipmi_lan_close(struct ipmi_intf * intf)
 	ipmi_intf_session_cleanup(intf);
 	intf->opened = 0;
 	intf->manufacturer_id = IPMI_OEM_UNKNOWN;
-	intf = NULL;
 }
 
 static int

--- a/src/plugins/lanplus/lanplus.c
+++ b/src/plugins/lanplus/lanplus.c
@@ -3303,7 +3303,7 @@ ipmi_lanplus_rakp3(struct ipmi_intf * intf)
  * ipmi_lan_close
  */
 void
-ipmi_lanplus_close(struct ipmi_intf * intf)
+ipmi_lanplus_close(struct ipmi_intf *intf)
 {
 	if (!intf->abort && intf->session)
 		ipmi_close_session_cmd(intf);
@@ -3317,7 +3317,6 @@ ipmi_lanplus_close(struct ipmi_intf * intf)
 	ipmi_intf_session_cleanup(intf);
 	intf->opened = 0;
 	intf->manufacturer_id = IPMI_OEM_UNKNOWN;
-	intf = NULL;
 }
 
 


### PR DESCRIPTION
Remove assignment to parameter in the close method:
[src/plugins/lan/lan.c:1886]:
[src/plugins/lanplus/lanplus.c:3320]:
(warning) Assignment of function parameter has no
effect outside the function.

Signed-off-by: Patrick Venture <venture@google.com>