### PR TITLE
[WIP] cleanup: lipmi

### DIFF
--- a/src/plugins/lipmi/lipmi.c
+++ b/src/plugins/lipmi/lipmi.c
@@ -80,8 +80,7 @@ ipmi_lipmi_send_cmd(struct ipmi_intf *intf, struct ipmi_rq *req)
 {
 	struct strioctl istr;
 	static struct lipmi_reqrsp reqrsp;
-	static struct ipmi_rs rsp;	
-	static int curr_seq = 0;
+	static struct ipmi_rs rsp;
 
 	if (!intf || !req)
 		return NULL;


### PR DESCRIPTION
[src/plugins/lipmi/lipmi.c:78]: (style) Variable
'curr_seq' is assigned a value that is never used.

Signed-off-by: Patrick Venture <venture@google.com>