### PR TITLE
Correct lanplus segment violation for truncated response.

### DIFF
--- a/src/plugins/lanplus/lanplus.c
+++ b/src/plugins/lanplus/lanplus.c
@@ -790,7 +790,7 @@ ipmi_lan_poll_single(struct ipmi_intf * intf)
 			 * rsp->data_len becomes the length of that data
 			 */
 			extra_data_length = payload_size - (offset - payload_start) - 1;
-			if (extra_data_length) {
+			if (extra_data_length > 0) {
 				rsp->data_len = extra_data_length;
 				memmove(rsp->data, rsp->data + offset, extra_data_length);
 			} else {
@@ -844,7 +844,7 @@ ipmi_lan_poll_single(struct ipmi_intf * intf)
 		}
 		read_sol_packet(rsp, &offset);
 		extra_data_length = payload_size - (offset - payload_start);
-		if (extra_data_length) {
+		if (extra_data_length > 0) {
 			rsp->data_len = extra_data_length;
 			memmove(rsp->data, rsp->data + offset, extra_data_length);
 		} else {


### PR DESCRIPTION
Correct segment violation in lanplus from dcmi truncated response.

 This corrects Issue #72.
    On occasion a dcmi power reading will return error C6, and a
    truncated response payload. As the decrypted payload is shorter
    than the expected length, lanplus_decrypt_aes_cbc_128() adjusts
    the payload_size downward by one byte. In ipmi_lan_poll_single()
    the calculation to determine if the payload size has increased
    erroniously sets extra_data_length to -1, with a subsequent
    segv when calling a memmove to shift response data.
    The fix is to check for a positive value in the extra_data_length.