### PR TITLE
helper: add FREE helper macro

### DIFF
--- a/include/ipmitool/helper.h
+++ b/include/ipmitool/helper.h
@@ -58,6 +58,12 @@
     #define __UNUSED__(x) x
 #endif
 
+#ifdef FREE
+#error "FREE already defined."
+#else
+#define FREE(PTR) do { free(PTR); (PTR) = NULL; } while(0);
+#endif
+
 /* IPMI spec. - UID 0 reserved, 63 maximum UID which can be used */
 #ifndef IPMI_UID_MIN
 # define IPMI_UID_MIN 1


### PR DESCRIPTION
Implement a free and nullify helper macro such
that developers need only call FREE(ptr) instead of

{
 free(ptr);
 ptr = NULL;
}

Partially resolves #79

Signed-off-by: Patrick Venture <venture@google.com>