### PR TITLE
helper: add free_n method to handle clearing pointers

### DIFF
--- a/include/ipmitool/helper.h
+++ b/include/ipmitool/helper.h
@@ -119,6 +119,17 @@ uint16_t ipmi_get_oem_id(struct ipmi_intf *intf);
 
 #define IS_SET(v, b) ((v) & (1 << (b)))
 
+/**
+ * Free the memory and clear the pointer.
+ * @param[in] ptr - a pointer to your pointer to free.
+ */
+static inline void free_n(void **ptr) {
+	if (ptr && *ptr) {
+		free(*ptr);
+		*ptr = NULL;
+	}
+}
+
 /* le16toh(), hto16le(), et. al. don't exist for Windows or Apple */
 /* For portability, let's simply define our own versions here */
 


### PR DESCRIPTION
free_n() will free the memory and clear the pointer, which will reduce
the probability a developer will forget to clear the pointer after
freeing.
Resolves: #79

Signed-off-by: Patrick Venture <venture@google.com>