### PR TITLE
Fixed two issues found by "cppcheck".

### DIFF
--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -1398,6 +1398,7 @@ HpmfwupgGetBufferFromFile(char *imageFilename,
 	if (ret != 0) {
 		lprintf(LOG_ERR, "Failed to seek in the image file '%s'",
 				imageFilename);
+		fclose(pImageFile);
 		return HPMFWUPG_ERROR;
 	}
 	pFwupgCtx->imageSize  = ftell(pImageFile);
@@ -2290,13 +2291,9 @@ HpmfwupgWaitLongDurationCmd(struct ipmi_intf *intf,
 			}
 		}
 	}
-	if (rc == HPMFWUPG_SUCCESS) {
-		/* Poll upgrade status until completion or timeout*/
-		timeoutSec1 = time(NULL);
-		timeoutSec2 = time(NULL);
-		rc = HpmfwupgGetUpgradeStatus(intf, &upgStatusCmd,
-				pFwupgCtx, 1);
-	}
+	/* Poll upgrade status until completion or timeout*/
+	timeoutSec2 = timeoutSec1 = time(NULL);
+	rc = HpmfwupgGetUpgradeStatus(intf, &upgStatusCmd, pFwupgCtx, 1);
 	while (
 			/* With KCS: Cover the case where we sometime
 			 * receive d5 (on the first get status) from


### PR DESCRIPTION
Fixed a resource leak by closing an open file before returning.
Removed an "if" with a condition which is always true to avoid confusion.
Also removed a call to "time()" in order to have two timestamps identical
at all times.