### PR TITLE
Prevent resource leak

### DIFF
--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -1398,6 +1398,7 @@ HpmfwupgGetBufferFromFile(char *imageFilename,
 	if (ret != 0) {
 		lprintf(LOG_ERR, "Failed to seek in the image file '%s'",
 				imageFilename);
+		fclose(pImageFile);
 		return HPMFWUPG_ERROR;
 	}
 	pFwupgCtx->imageSize  = ftell(pImageFile);


### PR DESCRIPTION
hpm: fclose(pImageFile) before returning from HpmfwupgGetBufferFromFile().