### PR TITLE
Rewrite function to centralized exiting

### DIFF
--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -1385,28 +1385,26 @@ int
 HpmfwupgGetBufferFromFile(char *imageFilename,
 		struct HpmfwupgUpgradeCtx *pFwupgCtx)
 {
-	int rc = HPMFWUPG_SUCCESS;
+	int rc = HPMFWUPG_ERROR;
 	int ret = 0;
 	FILE *pImageFile = fopen(imageFilename, "rb");
 	if (!pImageFile) {
 		lprintf(LOG_ERR, "Cannot open image file '%s'",
 				imageFilename);
-		return HPMFWUPG_ERROR;
+		goto ret_no_close;
 	}
 	/* Get the raw data in file */
 	ret = fseek(pImageFile, 0, SEEK_END);
 	if (ret != 0) {
 		lprintf(LOG_ERR, "Failed to seek in the image file '%s'",
 				imageFilename);
-		fclose(pImageFile);
-		return HPMFWUPG_ERROR;
+		goto ret_close;
 	}
 	pFwupgCtx->imageSize  = ftell(pImageFile);
 	pFwupgCtx->pImageData = malloc(sizeof(unsigned char)*pFwupgCtx->imageSize);
 	if (!pFwupgCtx->pImageData) {
 		lprintf(LOG_ERR, "ipmitool: malloc failure");
-		fclose(pImageFile);
-		return HPMFWUPG_ERROR;
+		goto ret_close;
 	}
 	rewind(pImageFile);
 	ret = fread(pFwupgCtx->pImageData,
@@ -1418,9 +1416,14 @@ HpmfwupgGetBufferFromFile(char *imageFilename,
 				"Failed to read file %s size %d", 
 				imageFilename,
 				pFwupgCtx->imageSize);
-		rc = HPMFWUPG_ERROR;
+		goto ret_close;
 	}
+
+	rc = HPMFWUPG_SUCCESS;
+
+ret_close:
 	fclose(pImageFile);
+ret_no_close:
 	return rc;
 }
 

--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -2291,13 +2291,9 @@ HpmfwupgWaitLongDurationCmd(struct ipmi_intf *intf,
 			}
 		}
 	}
-	if (rc == HPMFWUPG_SUCCESS) {
-		/* Poll upgrade status until completion or timeout*/
-		timeoutSec1 = time(NULL);
-		timeoutSec2 = time(NULL);
-		rc = HpmfwupgGetUpgradeStatus(intf, &upgStatusCmd,
-				pFwupgCtx, 1);
-	}
+	/* Poll upgrade status until completion or timeout*/
+	timeoutSec2 = timeoutSec1 = time(NULL);
+	rc = HpmfwupgGetUpgradeStatus(intf, &upgStatusCmd, pFwupgCtx, 1);
 	while (
 			/* With KCS: Cover the case where we sometime
 			 * receive d5 (on the first get status) from

--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -1398,6 +1398,7 @@ HpmfwupgGetBufferFromFile(char *imageFilename,
 	if (ret != 0) {
 		lprintf(LOG_ERR, "Failed to seek in the image file '%s'",
 				imageFilename);
+		fclose(pImageFile);
 		return HPMFWUPG_ERROR;
 	}
 	pFwupgCtx->imageSize  = ftell(pImageFile);


### PR DESCRIPTION
hpm: Replace return()s with gotos to appropriate labels (with or without closing file).