### PR TITLE
create_pen_list: only print if values are set

### DIFF
--- a/lib/create_pen_list
+++ b/lib/create_pen_list
@@ -67,7 +67,9 @@ parse_pen_list() {
       }
 
       END {
-          print "{ " PEN ", \"" ENTERPRISE "\" },"
+          if(PEN) {
+            print "{ " PEN ", \"" ENTERPRISE "\" },"
+          }
       }'
 }
 


### PR DESCRIPTION
If a build environment doesn't have network access the fetch of the IANA PEN list will fail and the create_pen_list script will create invalid output causing the build to fail. This fixes the parsing.