### PR TITLE
hpm: improve the validation of buffer length when upload

### DIFF
--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -2252,7 +2252,8 @@ HpmfwupgSendCmd(struct ipmi_intf *intf, struct ipmi_rq req,
 			retry = 0;
 			if (req.msg.netfn == IPMI_NETFN_PICMG
 					&& req.msg.cmd == HPMFWUPG_UPLOAD_FIRMWARE_BLOCK
-					&& (!isValidSize)) {
+					&& (!isValidSize)
+					&& (rsp->ccode != IPMI_CC_REQ_DATA_INV_LENGTH)) {
 				lprintf(LOG_INFO,
 						"Buffer length is now considered valid");
 				isValidSize = TRUE;

--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -53,6 +53,8 @@ uint16_t
 ipmi_intf_get_max_request_data_size(struct ipmi_intf * intf);
 
 extern int verbose;
+static unsigned char isValidSize = FALSE;
+static int errorCount = 0;
 
 int HpmfwupgUpgrade(struct ipmi_intf *intf, char *imageFilename,
 		int activate, int, int);
@@ -1190,6 +1192,8 @@ HpmFwupgActionUploadFirmware(struct HpmfwupgComponentBitMask components,
 		lengthOfBlock = firmwareLength;
 		totalSent = 0x00;
 		displayFWLength= firmwareLength;
+		isValidSize = FALSE;
+		errorCount = 0;
 		time(&start);
 		while ((pData < (pDataTemp+lengthOfBlock)) && (rc == HPMFWUPG_SUCCESS)) {
 			if ((pData+bufLength) <= (pDataTemp+lengthOfBlock)) {
@@ -2148,13 +2152,11 @@ HpmfwupgSendCmd(struct ipmi_intf *intf, struct ipmi_rq req,
 	}
 	timeoutSec1 = time(NULL);
 	do {
-		static unsigned char isValidSize = FALSE;
 		rsp = intf->sendrecv(intf, &req);
 		if (!rsp) {
 			#define HPM_LAN_PACKET_RESIZE_LIMIT 6
 			/* also covers lanplus */
 			if (strstr(intf->name, "lan")) {
-				static int errorCount=0;
 				static struct ipmi_rs fakeRsp;
 				lprintf(LOG_DEBUG,
 						"HPM: no response available");

--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -1212,8 +1212,8 @@ HpmFwupgActionUploadFirmware(struct HpmfwupgComponentBitMask components,
 				if (rc == HPMFWUPG_UPLOAD_BLOCK_LENGTH && !bufLengthIsSet) {
 					rc = HPMFWUPG_SUCCESS;
 					/* Retry with a smaller buffer length */
-					if (strstr(intf->name,"lan") && bufLength > 8) {
-						bufLength-= 8;
+					if (strstr(intf->name,"lan") && bufLength > 2) {
+						bufLength >>= 1;
 						lprintf(LOG_INFO,
 								"Trying reduced buffer length: %d",
 								bufLength);


### PR DESCRIPTION
To resolve bug:
Fail to update HPM package if give large argument following -z #106

Ocean.