### PR TITLE
Update ipmi_intf.h

### DIFF
--- a/include/ipmitool/ipmi_intf.h
+++ b/include/ipmitool/ipmi_intf.h
@@ -244,6 +244,9 @@ struct ipmi_intf {
 struct ipmi_intf * ipmi_intf_load(char * name);
 void ipmi_intf_print(struct ipmi_intf_support * intflist);
 
+uint16_t ipmi_intf_get_max_request_data_size(struct ipmi_intf * intf);
+uint16_t ipmi_intf_get_max_response_data_size(struct ipmi_intf * intf);
+
 void ipmi_intf_session_set_hostname(struct ipmi_intf * intf, char * hostname);
 void ipmi_intf_session_set_username(struct ipmi_intf * intf, char * username);
 void ipmi_intf_session_set_password(struct ipmi_intf * intf, char * password);

--- a/lib/create_pen_list
+++ b/lib/create_pen_list
@@ -45,7 +45,7 @@ if [ -z "$OUTFILE" ]; then
 fi
 
 parse_pen_list() {
-  iconv -f utf8 -t ascii//TRANSLIT//IGNORE \
+  iconv -f UTF-8 -t ascii//TRANSLIT//IGNORE \
     | awk '
       /^[0-9]+/ {
         if(PEN) {


### PR DESCRIPTION
```
ipmi_fru.c:528:26: warning: implicit declaration of function 'ipmi_intf_get_max_request_data_size' is invalid in C99 [-Wimplicit-function-declaration]
                uint16_t max_rq_size = ipmi_intf_get_max_request_data_size(intf);
                                       ^
ipmi_fru.c:698:26: warning: implicit declaration of function 'ipmi_intf_get_max_response_data_size' is invalid in C99 [-Wimplicit-function-declaration]
                uint16_t max_rs_size = ipmi_intf_get_max_response_data_size(intf) - 1;
                                       ^

```