### PR TITLE
Add mechanism to configure to set the default interface

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -671,6 +671,25 @@ AC_TRY_COMPILE([],[
 		[Define to 1 if you need to use #pragma pack instead of __attribute__ ((packed))])]
 )
 
+dnl if no environment variable is set, set the default value for the default intf
+if test "${xenable_intf_open}" = "xyes"; then
+   DEFAULT_INTF_NO_ENV=open
+else dnl macOS does not build open interface, it defaults to lan
+   DEFAULT_INTF_NO_ENV=lan
+fi
+dnl allow for a default interface to be set on configure
+AC_ARG_VAR(DEFAULT_INTF, [Set the default interface to use (default=${DEFAULT_INTF_NO_ENV})])
+
+dnl set the default value for the default interface environment variable
+if test "x${DEFAULT_INTF}" == "x"; then
+	echo "DEFAULT_INTF not found in environment; setting to ${DEFAULT_INTF_NO_ENV}"
+	DEFAULT_INTF=${DEFAULT_INTF_NO_ENV}
+fi
+
+xdefault_intf_is_enabled="xenable_intf_${DEFAULT_INTF}"
+if test "x${!xdefault_intf_is_enabled}" != "xyes"; then
+	AC_MSG_ERROR([** Cannot set ${DEFAULT_INTF} as default; ${DEFAULT_INTF} is not enabled. :${!xdefault_intf_is_enabled}:])
+fi
 
 dnl Generate files for build
 AC_CONFIG_FILES([Makefile
@@ -703,7 +722,7 @@ AC_OUTPUT
 AC_MSG_RESULT([])
 AC_MSG_RESULT([ipmitool $VERSION])
 AC_MSG_RESULT([])
-AC_MSG_RESULT([Interfaces])
+AC_MSG_RESULT([Interfaces (default=$DEFAULT_INTF)])
 AC_MSG_RESULT([  lan     : $xenable_intf_lan])
 AC_MSG_RESULT([  lanplus : $xenable_intf_lanplus])
 AC_MSG_RESULT([  open    : $xenable_intf_open])

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -37,6 +37,7 @@ DIST_SUBDIRS			= lan lanplus open lipmi imb bmc free serial dummy usb dbus
 
 noinst_LTLIBRARIES		= libintf.la
 libintf_la_SOURCES		= ipmi_intf.c
+libintf_la_CFLAGS		= -DDEFAULT_INTF='"@DEFAULT_INTF@"'
 libintf_la_LDFLAGS		= -export-dynamic
 libintf_la_LIBADD		= @IPMITOOL_INTF_LIB@
 libintf_la_DEPENDENCIES		= @IPMITOOL_INTF_LIB@

--- a/src/plugins/ipmi_intf.c
+++ b/src/plugins/ipmi_intf.c
@@ -128,6 +128,26 @@ struct ipmi_intf * ipmi_intf_table[] = {
 	NULL
 };
 
+/* get_default_interface - return the interface that was chosen by configure
+ *
+ * returns a valid interface pointer
+ */
+static struct ipmi_intf *get_default_interface(void)
+{
+	static const char *default_intf_name = DEFAULT_INTF;
+	struct ipmi_intf ** intf;
+	for (intf = ipmi_intf_table; intf && *intf; intf++) {
+		if (!strcmp(default_intf_name, (*intf)->name)) {
+			return *intf;
+		}
+	}
+	/* code should never reach this because the configure script checks
+	 * to see that the default interface is actually enabled, but we have
+	 * to return some valid value here, so the first entry works
+	 */
+	return ipmi_intf_table[0];
+}
+
 /* ipmi_intf_print  -  Print list of interfaces
  *
  * no meaningful return code
@@ -135,10 +155,11 @@ struct ipmi_intf * ipmi_intf_table[] = {
 void ipmi_intf_print(struct ipmi_intf_support * intflist)
 {
 	struct ipmi_intf ** intf;
+	struct ipmi_intf *def_intf;
 	struct ipmi_intf_support * sup;
-	int def = 1;
 	int found;
 
+	def_intf = get_default_interface();
 	lprintf(LOG_NOTICE, "Interfaces:");
 
 	for (intf = ipmi_intf_table; intf && *intf; intf++) {
@@ -157,8 +178,7 @@ void ipmi_intf_print(struct ipmi_intf_support * intflist)
 
 		lprintf(LOG_NOTICE, "\t%-12s  %s %s",
 			(*intf)->name, (*intf)->desc,
-			def ? "[default]" : "");
-		def = 0;
+			def_intf == (*intf) ? "[default]" : "");
 	}
 	lprintf(LOG_NOTICE, "");
 }
@@ -177,7 +197,7 @@ struct ipmi_intf * ipmi_intf_load(char * name)
 	struct ipmi_intf * i;
 
 	if (!name) {
-		i = ipmi_intf_table[0];
+		i = get_default_interface();
 		if (i->setup && (i->setup(i) < 0)) {
 			lprintf(LOG_ERR, "Unable to setup "
 				"interface %s", name);


### PR DESCRIPTION
In some cases, the user may want to have a different default interface
without the need to always specify it on the command line. Add a
configure option that sets the default interface without the need to
patch the code.

Configure as: ./configure DEFAULT_INTF=name
where name is an interface name that might be enabled with
--enable-intf-<name>.

The configure will enforce that the selected default interface is
enabled.

Signed-off-by: Vernon Mauery <vernon.mauery@intel.com>