### PR TITLE
Feature/add support for boot mailbox

### DIFF
--- a/doc/ipmitool.1
+++ b/doc/ipmitool.1
@@ -473,6 +473,34 @@ Force boot into BIOS Setup.
 
 Force boot from Floppy/primary removable media.
 .RE
+
+.TP
+\fIbootmbox\fP \fIget\fP [text] [block <\fBblock#\fP>]
+
+Read the Boot Initiator Mailbox in hex dump or in text mode.
+
+By default the whole mailbox is read. If block number is specified,
+that particular block is read. For block 0 or when the whole
+mailbox is read, the Boot Initiator IANA Enterprise Number and
+the corresponding enterprise name are printed.
+
+.TP
+\fIbootmbox\fP \fIset\fP text [block <\fBblock#\fP>] <\fBIANA_PEN\fP> "<\fBdata_string\fP>"
+
+Write the specified <block> or the entire Boot Initiator Mailbox in text mode.
+It is required to specify a decimal IANA Enterprise Number recognized
+by the boot initiator on the target system. Refer to your target system
+manufacturer for details. The rest of the arguments are a text string.
+
+When single block write is requested, the total length of <data> may not
+exceed 13 bytes for block 0, or 16 bytes otherwise.
+
+.TP
+\fIbootmbox\fP \fIset\fP [block <\fBblock#\fP>] <\fBIANA_PEN\fP> <\fBdata_byte\fP> [<\fBdata_byte\fP> ...]
+
+Same as above, but the arguments after IANA PEN are separate
+data byte values separated by spaces.
+
 .TP 
 \fIbootparam\fP \fIget\fP <\fBopt_id\fR> [<\fBopt_param\fR>]
 

--- a/doc/ipmitool.1
+++ b/doc/ipmitool.1
@@ -474,35 +474,65 @@ Force boot into BIOS Setup.
 Force boot from Floppy/primary removable media.
 .RE
 .TP 
-\fIbootparam\fP
-.RS
+\fIbootparam\fP \fIget\fP <\fBopt_id\fR> [<\fBopt_param\fR>]
+
+Get value of system boot option number <\fBopt_id\fR>. Some boot
+options (e.g. option 7) can also take an optional numeric parameter.
+
 .TP 
-\fIforce_pxe\fP
+\fIbootparam\fP \fIset\fP bootflag <\fBdevice\fR> [options=...]
+
+Set a boot flag. Valid devices are:
+
+.RS
+.IP \fIforce_pxe\fP
 
 Force PXE boot
-.TP 
-\fIforce_disk\fP
+.IP \fIforce_disk\fP
 
 Force boot from default Hard-drive
-.TP 
-\fIforce_safe\fP
+.IP \fIforce_safe\fP
 
 Force boot from default Hard-drive, request Safe Mode
-.TP 
-\fIforce_diag\fP
+.IP \fIforce_diag\fP
 
 Force boot from Diagnostic Partition
-.TP 
-\fIforce_cdrom\fP
+.IP \fIforce_cdrom\fP
 
 Force boot from CD/DVD
-.TP 
-\fIforce_bios\fP
+.IP \fIforce_bios\fP
 
 Force boot into BIOS Setup
+
+.PP
+Valid options are:
+
+.IP \fIPEF\fP
+
+Clear valid bit on reset/power cycle cause by PEF
+
+.IP \fItimeout\fP
+
+Automatically clear boot flag valid bit on timeout
+
+.IP \fIwatchdog\fP
+
+Clear valid bit on reset/power cycle cause by watchdog
+
+.IP \fIreset\fP
+
+Clear valid bit on push button reset/soft reset
+
+.IP \fIpower\fP
+
+Clear valid bit on power up via power push button or wake event
 .RE
+
 .TP 
 \fIselftest\fP
+
+Get the chassis self-test results
+
 .RE
 .TP 
 \fIdcmi\fP

--- a/include/ipmitool/helper.h
+++ b/include/ipmitool/helper.h
@@ -169,6 +169,13 @@ static inline uint32_t ipmi24toh(void *ipmi24)
 	return h;
 }
 
+static inline void htoipmi24(uint32_t h, uint8_t *ipmi)
+{
+	ipmi[0] = h & 0xFF; /* LSB */
+	ipmi[1] = (h >> 8) & 0xFF;
+	ipmi[2] = (h >> 16) & 0xFF; /* MSB */
+}
+
 static inline uint32_t ipmi32toh(void *ipmi32)
 {
 	uint8_t *ipmi = ipmi32;

--- a/include/ipmitool/helper.h
+++ b/include/ipmitool/helper.h
@@ -80,6 +80,10 @@ struct oemvalstr {
 	const char * str;
 };
 
+const char *
+specific_val2str(uint16_t val,
+                 const struct valstr *specific,
+                 const struct valstr *generic);
 const char * val2str(uint16_t val, const struct valstr * vs);
 const char * oemval2str(uint32_t oem,uint16_t val, const struct oemvalstr * vs);
 

--- a/include/ipmitool/helper.h
+++ b/include/ipmitool/helper.h
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h> /* For free() */
+#include <stdbool.h>
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
@@ -91,6 +92,8 @@ int str2short(const char * str, int16_t * shrt_ptr);
 int str2ushort(const char * str, uint16_t * ushrt_ptr);
 int str2char(const char * str, int8_t * chr_ptr);
 int str2uchar(const char * str, uint8_t * uchr_ptr);
+
+bool args2buf(int argc, char *argv[], uint8_t *out, size_t len);
 
 int eval_ccode(const int ccode);
 

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -1080,3 +1080,35 @@ ipmi_get_oem_id(struct ipmi_intf *intf)
 
 	return oem_id;
 }
+
+/** Parse command line arguments as numeric byte values (dec or hex)
+ *  and store them in a \p len sized buffer \p out.
+ *
+ * @param[in] argc Number of arguments
+ * @param[in] argv Array of arguments
+ * @param[out] out The output buffer
+ * @param[in] len Length of the output buffer in bytes (no null-termination
+ *                is assumed, the input data is treated as raw byte values,
+ *                not as a string.
+ *
+ * @returns A success status indicator
+ * @return false Error
+ * @return true Success
+ */
+bool
+args2buf(int argc, char *argv[], uint8_t *out, size_t len)
+{
+	size_t i;
+
+	for (i = 0; i < len && i < (size_t)argc; ++i) {
+		uint8_t byte;
+
+		if (str2uchar(argv[i], &byte)) {
+			lprintf(LOG_ERR, "Bad byte value: %s", argv[i]);
+			return false;
+		}
+
+		out[i] = byte;
+	}
+	return true;
+}

--- a/lib/ipmi_chassis.c
+++ b/lib/ipmi_chassis.c
@@ -46,6 +46,18 @@
 
 extern int verbose;
 
+const static struct valstr get_bootparam_cc_vals[] = {
+	{ 0x80, "Unsupported parameter" },
+	{ 0x00, NULL }
+};
+
+const static struct valstr set_bootparam_cc_vals[] = {
+	{ 0x80, "Unsupported parameter" },
+	{ 0x81, "Attempt to set 'in progress' while not in 'complete' state" },
+	{ 0x82, "Parameter is read-only" },
+	{ 0x00, NULL }
+};
+
 int
 ipmi_chassis_power_status(struct ipmi_intf * intf)
 {
@@ -469,8 +481,12 @@ ipmi_chassis_set_bootparam(struct ipmi_intf * intf, uint8_t param, uint8_t * dat
 	}
 	if (rsp->ccode) {
 		if (param != 0) {
-			lprintf(LOG_ERR, "Set Chassis Boot Parameter %d failed: %s",
-					param, val2str(rsp->ccode, completion_code_vals));
+			lprintf(LOG_ERR,
+				"Set Chassis Boot Parameter %d failed: %s",
+				param,
+				specific_val2str(rsp->ccode,
+				                 set_bootparam_cc_vals,
+				                 completion_code_vals));
 		}
 		return rsp->ccode;
 	}
@@ -514,8 +530,12 @@ ipmi_chassis_get_bootparam(struct ipmi_intf * intf, char * arg)
 		return -1;
 	}
 	if (rsp->ccode) {
-		lprintf(LOG_ERR, "Get Chassis Boot Parameter %s failed: %s",
-				arg, val2str(rsp->ccode, completion_code_vals));
+		lprintf(LOG_ERR,
+		        "Get Chassis Boot Parameter %s failed: %s",
+		        arg,
+		        specific_val2str(rsp->ccode,
+		                         get_bootparam_cc_vals,
+		                         completion_code_vals));
 		return -1;
 	}
 
@@ -832,7 +852,10 @@ ipmi_chassis_get_bootvalid(struct ipmi_intf * intf)
 	}
 	if (rsp->ccode) {
 		lprintf(LOG_ERR, "Get Chassis Boot Parameter %d failed: %s",
-			param_id, val2str(rsp->ccode, completion_code_vals));
+		        param_id,
+		        specific_val2str(rsp->ccode,
+		                         get_bootparam_cc_vals,
+		                         completion_code_vals));
 		return -1;
 	}
 


### PR DESCRIPTION
This is an effort to add support for the Boot Initiator Mailbox system boot option.
Before this change the option could only be dumped as a whole in hex dump mode using `bootparam get 7`. With this change set it becomes possible to dump a single block using `bootparam get 7 <id>` as well as using `bootmbox get block <id>`. Also added are text dump function (`bootmbox get text`), and the function to set the mailbox value in both text and binary modes (`bootmbox set [text] [block <id>]`).