### PR TITLE
Fix default interface to behave as it did before

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -672,13 +672,13 @@ AC_TRY_COMPILE([],[
 )
 
 dnl if no environment variable is set, set the default value for the default intf
-if test "${xenable_intf_open}" = "xyes"; then
+if test "${xenable_intf_open}" = "yes"; then
    DEFAULT_INTF_NO_ENV=open
 else dnl macOS does not build open interface, it defaults to lan
    DEFAULT_INTF_NO_ENV=lan
 fi
 dnl allow for a default interface to be set on configure
-AC_ARG_VAR(DEFAULT_INTF, [Set the default interface to use (default=${DEFAULT_INTF_NO_ENV})])
+AC_ARG_VAR(DEFAULT_INTF, [Set the default interface to use (default='open' if available, 'lan' otherwise)])
 
 dnl set the default value for the default interface environment variable
 if test "x${DEFAULT_INTF}" == "x"; then


### PR DESCRIPTION
Prior to 95038ba01b99153de870dde91406bdc1c7265217 the default interface
was 'open' for builds where it was available and 'lan' otherwise. Due to
a logic error in 95038ba01b99153de870dde91406bdc1c7265217, the default
interface was always getting set to lan unless it was specified by the
environment variable. This commit fixes the logic and sets the default
to open if it is available and lan otherwise.

Resolves ipmitool/ipmitool#128

Tested: ./configure # no options reports 'open' as default
        ./configure --enable-intf-open=no # reports lan as default
	./configure --enable-intf-dbus DEFAULT_INTF=dbus
	# reports dbus as default

Signed-off-by: Vernon Mauery <vernon.mauery@intel.com>