### PR TITLE
mc: Fix reporting of manufacturers > 64K

### DIFF
--- a/include/ipmitool/helper.h
+++ b/include/ipmitool/helper.h
@@ -81,11 +81,11 @@ struct oemvalstr {
 };
 
 const char *
-specific_val2str(uint16_t val,
+specific_val2str(uint32_t val,
                  const struct valstr *specific,
                  const struct valstr *generic);
-const char * val2str(uint16_t val, const struct valstr * vs);
-const char * oemval2str(uint32_t oem,uint16_t val, const struct oemvalstr * vs);
+const char *val2str(uint32_t val, const struct valstr * vs);
+const char *oemval2str(uint32_t oem, uint32_t val, const struct oemvalstr * vs);
 
 int str2double(const char * str, double * double_ptr);
 int str2long(const char * str, int64_t * lng_ptr);
@@ -106,7 +106,11 @@ int is_ipmi_channel_num(const char *argv_ptr, uint8_t *channel_ptr);
 int is_ipmi_user_id(const char *argv_ptr, uint8_t *ipmi_uid_ptr);
 int is_ipmi_user_priv_limit(const char *argv_ptr, uint8_t *ipmi_priv_limit_ptr);
 
-uint16_t str2val(const char * str, const struct valstr * vs);
+uint32_t str2val32(const char *str, const struct valstr *vs);
+static inline uint16_t str2val(const char *str, const struct valstr *vs)
+{
+	return (uint16_t)str2val32(str, vs);
+}
 void print_valstr(const struct valstr * vs, const char * title, int loglevel);
 void print_valstr_2col(const struct valstr * vs, const char * title, int loglevel);
 

--- a/lib/helper.c
+++ b/lib/helper.c
@@ -329,7 +329,7 @@ mac2str(const uint8_t *buf)
  */
 static
 inline
-off_t find_val_idx(uint16_t val, const struct valstr *vs)
+off_t find_val_idx(uint32_t val, const struct valstr *vs)
 {
 	if (vs) {
 		for (off_t i = 0; vs[i].str; ++i) {
@@ -351,7 +351,7 @@ off_t find_val_idx(uint16_t val, const struct valstr *vs)
  */
 static
 inline
-const char *unknown_val_str(uint16_t val)
+const char *unknown_val_str(uint32_t val)
 {
 	static char un_str[32];
 	memset(un_str, 0, 32);
@@ -361,7 +361,7 @@ const char *unknown_val_str(uint16_t val)
 }
 
 const char *
-specific_val2str(uint16_t val,
+specific_val2str(uint32_t val,
                  const struct valstr *specific,
                  const struct valstr *generic)
 {
@@ -378,14 +378,14 @@ specific_val2str(uint16_t val,
 	return unknown_val_str(val);
 }
 
-const char * val2str(uint16_t val, const struct valstr *vs)
+const char *val2str(uint32_t val, const struct valstr *vs)
 {
 	return specific_val2str(val, NULL, vs);
 }
 
 
-const char * oemval2str(uint32_t oem, uint16_t val,
-                                             const struct oemvalstr *vs)
+const char *oemval2str(uint32_t oem, uint32_t val,
+                       const struct oemvalstr *vs)
 {
 	int i;
 
@@ -642,7 +642,7 @@ int str2uchar(const char * str, uint8_t * uchr_ptr)
 	return 0;
 } /* str2uchar(...) */
 
-uint16_t str2val(const char *str, const struct valstr *vs)
+uint32_t str2val32(const char *str, const struct valstr *vs)
 {
 	int i;
 


### PR DESCRIPTION
If a manufacturer's IANA PEN (aka manufacturer ID) was above
65535, it wasn't reported properly. Luckily there are no such
IDs so far, the biggest is 54077 as of 2019/06/18.

There is, however, an ID 0xFFFFFE used by fake_ipmistack
for debug purposes, and it was not reported correctly.

This commit expands the value argument to string searching functions
from 16-bit to 32-bit to allow for any possible IANA PEN.

Fixes: 73d6af57827fc85e78c700ca1dff00b3dbc63948
Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>