### PR TITLE
oem: Add product name for Supermicro SMT-X9

### DIFF
--- a/lib/ipmi_strings.c
+++ b/lib/ipmi_strings.c
@@ -269,7 +269,8 @@ const struct oemvalstr ipmi_oem_product_info[] = {
    { IPMI_OEM_ADLINK_24339, 0x0410, "MXN-0410" },
    { IPMI_OEM_ADLINK_24339, 0x2600, "MCN-2600" },
    { IPMI_OEM_ADLINK_24339, 0x1500, "MCN-1500" },
-
+   /* Super Micro */
+   { IPMI_OEM_SUPERMICRO, 0x0664, "SMT-X9" },
    /* YADRO */
    { IPMI_OEM_YADRO, 0x0001, "VESNIN BMC" },
    { IPMI_OEM_YADRO, 0x000A, "TATLIN Storage Controller BMC" },


### PR DESCRIPTION
I wanted an easy way to confirm I had the right firmware before flashing. This is supermicro's product name (and the name on their firmware package).
