### PR TITLE
Improve clarity of the "set password" length argument

### DIFF
--- a/doc/ipmitool.1.in
+++ b/doc/ipmitool.1.in
@@ -259,11 +259,15 @@ system.  It is thus recommended that IPMI password management only be done
 over IPMIv2.0 \fIlanplus\fP interface or the system interface on the
 local station.
 
-For IPMI v1.5, the maximum password length is 16 characters.
-Passwords longer than 16 characters will be truncated.
+For IPMI v1.5, the maximum password length is 16 characters; longer
+passwords might be truncated or rejected by the server, or rejected
+by
+.BR ipmitool .
 
-For IPMI v2.0, the maximum password length is 20 characters;
-longer passwords are truncated.
+For IPMI v2.0, the maximum password length is 20 characters; longer
+passwords will be rejected by
+.BR ipmitool .
+
 .SH "COMMANDS"
 .TP 
 \fIhelp\fP
@@ -3526,12 +3530,13 @@ Displays a list of user information for all defined userids.
 
 Sets the username associated with the given userid.
 .TP 
-\fIpassword\fP <\fBuserid\fR> [<\fBpassword\fR>]
+\fIpassword\fP <\fBuserid\fR> [<\fBpassword\fR> [<\fB16|20\fR>]]
 .br 
 
 Sets the password for the given userid.  If no password is given,
 the password is cleared (set to the NULL password).  Be careful when
-removing passwords from administrator\-level accounts.
+removing passwords from administrator\-level accounts.  If specified,
+16 or 20 determines the maximum password length.
 .RE
 .TP 
 \fIdisable\fP <\fBuserid\fR>

--- a/lib/ipmi_user.c
+++ b/lib/ipmi_user.c
@@ -657,24 +657,25 @@ ipmi_user_password(struct ipmi_intf *intf, int argc, char **argv)
 		}
 	} else {
 		password = argv[3];
-		if (argc > 4) {
-			if ((str2uchar(argv[4], &password_type) != 0)
-					|| (password_type != 16 && password_type != 20)) {
-				lprintf(LOG_ERR, "Invalid password length '%s'", argv[4]);
-				return (-1);
-			}
-		} else {
-			password_type = 16;
-		}
 	}
+	
+        if (argc > 4) {
+                if ((str2uchar(argv[4], &password_type) != 0)
+                                || (password_type != 16 && password_type != 20)) {
+                        lprintf(LOG_ERR, "Invalid password length '%s'", argv[4]);
+                        return (-1);
+                }
+        } else if (strlen(password) > 16) {
+                password_type = 20;
+        }
 
-	if (!password) {
-		lprintf(LOG_ERR, "Unable to parse password argument.");
-		return (-1);
-	} else if (strlen(password) > 20) {
-		lprintf(LOG_ERR, "Password is too long (> 20 bytes)");
-		return (-1);
-	}
+        if (!password) {
+                lprintf(LOG_ERR, "Unable to parse password argument.");
+                return (-1);
+        } else if (strlen(password) > password_type) {
+                lprintf(LOG_ERR, "Password is too long (> %d bytes)", password_type);
+                return (-1);
+        }
 
 	ccode = _ipmi_set_user_password(intf, user_id,
 			IPMI_PASSWORD_SET_PASSWORD, password,

--- a/lib/ipmi_user.c
+++ b/lib/ipmi_user.c
@@ -434,7 +434,7 @@ print_user_usage(void)
 	lprintf(LOG_NOTICE,
 "               set name     <user id> <username>");
 	lprintf(LOG_NOTICE,
-"               set password <user id> [<password> <16|20>]");
+"               set password <user id> [<password> [<16|20>]]");
 	lprintf(LOG_NOTICE,
 "               disable      <user id>");
 	lprintf(LOG_NOTICE,


### PR DESCRIPTION
Some small changes to the tool documentation / man page to make it clearer how the password length argument is handled.