### PR TITLE
Fix options= parsing for persistent and efiboot

### DIFF
--- a/lib/ipmi_chassis.c
+++ b/lib/ipmi_chassis.c
@@ -1714,9 +1714,9 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 					/* data 1 */
 					{"valid", 0, (1<<7), (1<<7),
 						"Boot flags valid"},
-					{"persistent", 0, (1<<6), (1<<6),
+					{"persistent", 0, (0xe0), (1<<6),
 						"Changes are persistent for all future boots"},
-					{"efiboot", 0, (1<<5), (1<<5),
+					{"efiboot", 0, (0xe0), (1<<5),
 						"Extensible Firmware Interface Boot (EFI)"},
 					/* data 2 */
 					{"clear-cmos", 1, (1<<7), (1<<7),


### PR DESCRIPTION
When using 'persistent' and/or 'efiboot' in an 'options=' like this:
  ipmitool -I lanplus chassis bootdev disk options=efiboot,persistent

Allow them to be used together. Previously if you specified them
together only the last one specified would take effect. That would
mean you could either specify to set for EFI or you could set it to be
persistent. But could not set EFI and persistent.

Changed the mask values so that they no longer wipe out previous
values.

Resolves: ipmitool#163