### PR TITLE
Fix/cleanup chassis bootparam and bootdev options

### DIFF
--- a/lib/ipmi_chassis.c
+++ b/lib/ipmi_chassis.c
@@ -1917,7 +1917,7 @@ bootdev_parse_options(char *optstring, uint8_t flags[])
 int
 ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 {
-	int rc = 0;
+	int rc = -1;
 
 	if ((argc == 0) || (strncmp(argv[0], "help", 4) == 0)) {
 		lprintf(LOG_NOTICE, "Chassis Commands:\n"
@@ -1936,11 +1936,12 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 
 		if ((argc < 2) || (strncmp(argv[1], "help", 4) == 0)) {
 			lprintf(LOG_NOTICE, "chassis power Commands: status, on, off, cycle, reset, diag, soft");
-			return 0;
+			rc = 0;
+			goto out;
 		}
 		if (strncmp(argv[1], "status", 6) == 0) {
 			rc = ipmi_chassis_print_power_status(intf);
-			return rc;
+			goto out;
 		}
 		if ((strncmp(argv[1], "up", 2) == 0) || (strncmp(argv[1], "on", 2) == 0))
 			ctl = IPMI_CHASSIS_CTL_POWER_UP;
@@ -1956,7 +1957,7 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 			ctl = IPMI_CHASSIS_CTL_ACPI_SOFT;
 		else {
 			lprintf(LOG_ERR, "Invalid chassis power command: %s", argv[1]);
-			return -1;
+			goto out;
 		}
 
 		rc = ipmi_chassis_power_control(intf, ctl);
@@ -2067,7 +2068,8 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 			}
 			if (optstr) {
 				if (!bootdev_parse_options(optstr, flags))
-					return -1;
+					goto out;
+
 				use_flags = true;
 			}
 			rc = ipmi_chassis_set_bootdev(intf, argv[1],
@@ -2081,8 +2083,8 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 	}
 	else {
 		lprintf(LOG_ERR, "Invalid chassis command: %s", argv[0]);
-		return -1;
 	}
 
+out:
 	return rc;
 }

--- a/lib/ipmi_chassis.c
+++ b/lib/ipmi_chassis.c
@@ -53,6 +53,96 @@
 #define CHASSIS_BOOT_MBOX_MAX_BLOCK 0xFF
 #define CHASSIS_BOOT_MBOX_MAX_BLOCKS (CHASSIS_BOOT_MBOX_MAX_BLOCK + 1)
 
+/* Get/Set system boot option boot flags bit definitions */
+/* Boot flags byte 1 bits */
+#define BF1_VALID_SHIFT 7
+#define BF1_INVALID 0
+#define BF1_VALID (1 << BF1_VALID_SHIFT)
+#define BF1_VALID_MASK BF1_VALID
+
+#define BF1_PERSIST_SHIFT 6
+#define BF1_ONCE 0
+#define BF1_PERSIST (1 << BF1_PERSIST_SHIFT)
+#define BF1_PERSIST_MASK BF1_PERSIST
+
+#define BF1_BOOT_TYPE_SHIFT 5
+#define BF1_BOOT_TYPE_LEGACY 0
+#define BF1_BOOT_TYPE_EFI (1 << BF1_BOOT_TYPE_SHIFT)
+#define BF1_BOOT_TYPE_MASK BF1_BOOT_TYPE_EFI
+
+/* Boot flags byte 2 bits */
+#define BF2_CMOS_CLEAR_SHIFT 7
+#define BF2_CMOS_CLEAR (1 << BF2_CMOS_CLEAR_SHIFT)
+#define BF2_CMOS_CLEAR_MASK BF2_CMOS_CLEAR
+
+#define BF2_KEYLOCK_SHIFT 6
+#define BF2_KEYLOCK (1 << BF2_KEYLOCK_SHIFT)
+#define BF2_KEYLOCK_MASK BF2_KEYLOCK
+
+#define BF2_BOOTDEV_SHIFT 2
+#define BF2_BOOTDEV_DEFAULT (0 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_PXE (1 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_HDD (2 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_HDD_SAFE (3 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_DIAG_PART (4 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_CDROM (5 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_SETUP (6 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_REMOTE_FDD (7 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_REMOTE_CDROM (8 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_REMOTE_PRIMARY_MEDIA (9 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_REMOTE_HDD (11 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_FDD  (15 << BF2_BOOTDEV_SHIFT)
+#define BF2_BOOTDEV_MASK (0xF << BF2_BOOTDEV_SHIFT)
+
+#define BF2_BLANK_SCREEN_SHIFT 1
+#define BF2_BLANK_SCREEN (1 << BF2_BLANK_SCREEN_SHIFT)
+#define BF2_BLANK_SCREEN_MASK BF2_BLANK_SCREEN
+
+#define BF2_RESET_LOCKOUT_SHIFT 0
+#define BF2_RESET_LOCKOUT (1 << BF2_RESET_LOCKOUT_SHIFT)
+#define BF2_RESET_LOCKOUT_MASK BF2_RESET_LOCKOUT
+
+/* Boot flags byte 3 bits */
+#define BF3_POWER_LOCKOUT_SHIFT 7
+#define BF3_POWER_LOCKOUT (1 << BF3_POWER_LOCKOUT_SHIFT)
+#define BF3_POWER_LOCKOUT_MASK BF3_POWER_LOCKOUT
+
+#define BF3_VERBOSITY_SHIFT 5
+#define BF3_VERBOSITY_DEFAULT (0 << BF3_VERBOSITY_SHIFT)
+#define BF3_VERBOSITY_QUIET (1 << BF3_VERBOSITY_SHIFT)
+#define BF3_VERBOSITY_VERBOSE (2 << BF3_VERBOSITY_SHIFT)
+#define BF3_VERBOSITY_MASK (3 << BF3_VERBOSITY_SHIFT)
+
+#define BF3_EVENT_TRAPS_SHIFT 4
+#define BF3_EVENT_TRAPS (1 << BF3_EVENT_TRAPS_SHIFT)
+#define BF3_EVENT_TRAPS_MASK BF3_EVENT_TRAPS
+
+#define BF3_PASSWD_BYPASS_SHIFT 3
+#define BF3_PASSWD_BYPASS (1 << BF3_PASSWD_BYPASS_SHIFT)
+#define BF3_PASSWD_BYPASS_MASK BF3_PASSWD_BYPASS
+
+#define BF3_SLEEP_LOCKOUT_SHIFT 2
+#define BF3_SLEEP_LOCKOUT (1 << BF3_SLEEP_LOCKOUT_SHIFT)
+#define BF3_SLEEP_LOCKOUT_MASK BF3_SLEEP_LOCKOUT
+
+#define BF3_CONSOLE_REDIR_SHIFT 0
+#define BF3_CONSOLE_REDIR_DEFAULT (0 << BF3_CONSOLE_REDIR_SHIFT)
+#define BF3_CONSOLE_REDIR_SUPPRESS (1 << BF3_CONSOLE_REDIR_SHIFT)
+#define BF3_CONSOLE_REDIR_ENABLE (2 << BF3_CONSOLE_REDIR_SHIFT)
+#define BF3_CONSOLE_REDIR_MASK (3 << BF3_CONSOLE_REDIR_SHIFT)
+
+/* Boot flags byte 4 bits */
+#define BF4_SHARED_MODE_SHIFT 3
+#define BF4_SHARED_MODE (1 << BF4_SHARED_MODE_SHIFT)
+#define BF4_SHARED_MODE_MASK BF4_SHARED_MODE
+
+#define BF4_BIOS_MUX_SHIFT 0
+#define BF4_BIOS_MUX_DEFAULT (0 << BF4_BIOS_MUX_SHIFT)
+#define BF4_BIOS_MUX_BMC (1 << BF4_BIOS_MUX_SHIFT)
+#define BF4_BIOS_MUX_SYSTEM (2 << BF4_BIOS_MUX_SHIFT)
+#define BF4_BIOS_MUX_MASK (7 << BF4_BIOS_MUX_SHIFT)
+
+
 typedef struct {
 	uint8_t iana[CHASSIS_BOOT_MBOX_IANA_SZ];
 	uint8_t data[CHASSIS_BOOT_MBOX_BLOCK0_SZ];
@@ -776,79 +866,147 @@ ipmi_chassis_get_bootparam(struct ipmi_intf * intf,
 		{
 			printf(   " Boot Flags :\n");
 
-			if((rsp->data[2]&0x80) == 0x80)
+			if(rsp->data[2] & BF1_VALID)
 				printf("   - Boot Flag Valid\n");
 			else
 				printf("   - Boot Flag Invalid\n");
 
-			if((rsp->data[2]&0x40) == 0x40)
+			if(rsp->data[2] & BF1_PERSIST)
 				printf("   - Options apply to all future boots\n");
 			else
 				printf("   - Options apply to only next boot\n");
 
-			if((rsp->data[2]&0x20) == 0x20)
+			if(rsp->data[2] & BF1_BOOT_TYPE_EFI)
 				printf("   - BIOS EFI boot \n");
 			else
 				printf("   - BIOS PC Compatible (legacy) boot \n");
 
-			if((rsp->data[3]&0x80) == 0x80)
+			if(rsp->data[3] & BF2_CMOS_CLEAR)
 				printf("   - CMOS Clear\n");
-			if((rsp->data[3]&0x40) == 0x40)
+			if(rsp->data[3] & BF2_KEYLOCK)
 				printf("   - Lock Keyboard\n");
 			printf("   - Boot Device Selector : ");
-			switch( ((rsp->data[3]>>2)&0x0f))
+			switch(rsp->data[3] & BF2_BOOTDEV_MASK)
 			{
-				case 0: printf("No override\n"); break;
-				case 1: printf("Force PXE\n"); break;
-				case 2: printf("Force Boot from default Hard-Drive\n"); break;
-				case 3: printf("Force Boot from default Hard-Drive, request Safe-Mode\n"); break;
-				case 4: printf("Force Boot from Diagnostic Partition\n"); break;
-				case 5: printf("Force Boot from CD/DVD\n"); break;
-				case 6: printf("Force Boot into BIOS Setup\n"); break;
-				case 15: printf("Force Boot from Floppy/primary removable media\n"); break;
-				default: printf("Flag error\n"); break;
+			case BF2_BOOTDEV_DEFAULT:
+				printf("No override\n");
+				break;
+			case BF2_BOOTDEV_PXE:
+				printf("Force PXE\n");
+				break;
+			case BF2_BOOTDEV_HDD:
+				printf("Force Boot from default Hard-Drive\n");
+				break;
+			case BF2_BOOTDEV_HDD_SAFE:
+				printf("Force Boot from default Hard-Drive, "
+				       "request Safe-Mode\n");
+				break;
+			case BF2_BOOTDEV_DIAG_PART:
+				printf("Force Boot from Diagnostic Partition\n");
+				break;
+			case BF2_BOOTDEV_CDROM:
+				printf("Force Boot from CD/DVD\n");
+				break;
+			case BF2_BOOTDEV_SETUP:
+				printf("Force Boot into BIOS Setup\n");
+				break;
+			case BF2_BOOTDEV_REMOTE_FDD:
+				printf("Force Boot from remotely connected "
+				       "Floppy/primary removable media\n");
+				break;
+			case BF2_BOOTDEV_REMOTE_CDROM:
+				printf("Force Boot from remotely connected "
+				       "CD/DVD\n");
+				break;
+			case BF2_BOOTDEV_REMOTE_PRIMARY_MEDIA:
+				printf("Force Boot from primary remote media\n");
+				break;
+			case BF2_BOOTDEV_REMOTE_HDD:
+				printf("Force Boot from remotely connected "
+				       "Hard-Drive\n");
+				break;
+			case BF2_BOOTDEV_FDD:
+				printf("Force Boot from Floppy/primary "
+				       "removable media\n");
+				break;
+			default:
+				 printf("Flag error\n");
+				 break;
 			}
-			if((rsp->data[3]&0x02) == 0x02)
+			if(rsp->data[3] & BF2_BLANK_SCREEN)
 				printf("   - Screen blank\n");
-			if((rsp->data[3]&0x01) == 0x01)
+			if(rsp->data[3] & BF2_RESET_LOCKOUT)
 				printf("   - Lock out Reset buttons\n");
 
-			if((rsp->data[4]&0x80) == 0x80)
-				printf("   - Lock out (power off/sleep request) vi Power Button\n");
-			printf("   - Console Redirection control : ");
-			switch( ((rsp->data[4]>>5)&0x03))
-			{
-				case 0: printf("System Default\n"); break;
-				case 1: printf("Request Quiet Display\n"); break;
-				case 2: printf("Request Verbose Display\n"); break;
-				default: printf("Flag error\n"); break;
-			}
-			if((rsp->data[4]&0x10) == 0x10)
-				printf("   - Force progress event traps\n");
-			if((rsp->data[4]&0x08) == 0x08)
-				printf("   - User password bypass\n");
-			if((rsp->data[4]&0x04) == 0x04)
-				printf("   - Lock Out Sleep Button\n");
-			if((rsp->data[4]&0x02) == 0x02)
-				printf("   - Lock Out Sleep Button\n");
+			if(rsp->data[4] & BF3_POWER_LOCKOUT)
+				printf("   - Lock out (power off/sleep "
+				       "request) via Power Button\n");
+
 			printf("   - BIOS verbosity : ");
-			switch( ((rsp->data[4]>>0)&0x03))
+			switch(rsp->data[4] & BF3_VERBOSITY_MASK)
 			{
-				case 0: printf("Console redirection occurs per BIOS configuration setting (default)\n"); break;
-				case 1: printf("Suppress (skip) console redirection if enabled\n"); break;
-				case 2: printf("Request console redirection be enabled\n"); break;
-				default: printf("Flag error\n"); break;
+			case BF3_VERBOSITY_DEFAULT:
+				printf("System Default\n");
+				break;
+			case BF3_VERBOSITY_QUIET:
+				printf("Request Quiet Display\n");
+				break;
+			case BF3_VERBOSITY_VERBOSE:
+				printf("Request Verbose Display\n");
+				break;
+			default:
+				printf("Flag error\n");
+				break;
+			}
+			if(rsp->data[4] & BF3_EVENT_TRAPS)
+				printf("   - Force progress event traps\n");
+			if(rsp->data[4] & BF3_PASSWD_BYPASS)
+				printf("   - User password bypass\n");
+			if(rsp->data[4] & BF3_SLEEP_LOCKOUT)
+				printf("   - Lock Out Sleep Button\n");
+			printf("   - Console Redirection control : ");
+			switch(rsp->data[4] & BF3_CONSOLE_REDIR_MASK)
+			{
+			case BF3_CONSOLE_REDIR_DEFAULT:
+				printf(
+				       "Console redirection occurs per BIOS "
+				       "configuration setting (default)\n");
+				break;
+			case BF3_CONSOLE_REDIR_SUPPRESS:
+				printf("Suppress (skip) console redirection "
+				       "if enabled\n");
+				break;
+			case BF3_CONSOLE_REDIR_ENABLE:
+				printf("Request console redirection be "
+				       "enabled\n");
+				break;
+			default:
+				printf("Flag error\n");
+				break;
 			}
 
-			if((rsp->data[5]&0x08) == 0x08)
+			if(rsp->data[5] & BF4_SHARED_MODE)
 				printf("   - BIOS Shared Mode Override\n");
 			printf("   - BIOS Mux Control Override : ");
-			switch( ((rsp->data[5]>>0)&0x07))
-			{
-				case 0: printf("BIOS uses recommended setting of the mux at the end of POST\n"); break;
-				case 1: printf("Requests BIOS to force mux to BMC at conclusion of POST/start of OS boot\n"); break;
-				case 2: printf("Requests BIOS to force mux to system at conclusion of POST/start of OS boot\n"); break;
-				default: printf("Flag error\n"); break;
+			switch (rsp->data[5] & BF4_BIOS_MUX_MASK) {
+			case BF4_BIOS_MUX_DEFAULT:
+				printf("BIOS uses recommended setting of the "
+				       "mux at the end of POST\n");
+				break;
+			case BF4_BIOS_MUX_BMC:
+				printf(
+				       "Requests BIOS to force mux to BMC at "
+				       "conclusion of POST/start of OS boot\n");
+				break;
+			case BF4_BIOS_MUX_SYSTEM:
+				printf(
+				       "Requests BIOS to force mux to system "
+				       "at conclusion of POST/start of "
+				       "OS boot\n");
+				break;
+			default:
+				printf("Flag error\n");
+				break;
 			}
 		}
 		break;
@@ -1706,49 +1864,144 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 				unsigned char flags[5];
 				static struct {
 					char *name;
-					int i;
+					off_t offset;
+					#define BF1_OFFSET 0
+					#define BF2_OFFSET 1
+					#define BF3_OFFSET 2
+					#define BF4_OFFSET 3
 					unsigned char mask;
 					unsigned char value;
 					char *desc;
-				} options[] = {
+				} *op, options[] = {
 					/* data 1 */
-					{"valid", 0, (1<<7), (1<<7),
-						"Boot flags valid"},
-					{"persistent", 0, (1<<6), (1<<6),
-						"Changes are persistent for all future boots"},
-					{"efiboot", 0, (1<<5), (1<<5),
-						"Extensible Firmware Interface Boot (EFI)"},
+					{
+						"valid",
+						BF1_OFFSET,
+						BF1_VALID_MASK,
+						BF1_VALID,
+						"Boot flags valid"
+					},
+					{
+						"persistent",
+						BF1_OFFSET,
+						BF1_PERSIST_MASK,
+						BF1_PERSIST,
+						"Changes are persistent for "
+							"all future boots"
+					},
+					{
+						"efiboot",
+						BF1_OFFSET,
+						BF1_BOOT_TYPE_MASK,
+						BF1_BOOT_TYPE_EFI,
+						"Extensible Firmware Interface "
+							"Boot (EFI)"
+					},
 					/* data 2 */
-					{"clear-cmos", 1, (1<<7), (1<<7),
-						"CMOS clear"},
-					{"lockkbd", 1, (1<<6), (1<<6),
-						"Lock Keyboard"},
+					{
+						"clear-cmos",
+						BF2_OFFSET,
+						BF2_CMOS_CLEAR_MASK,
+						BF2_CMOS_CLEAR,
+						"CMOS clear"
+					},
+					{
+						"lockkbd",
+						BF2_OFFSET,
+						BF2_KEYLOCK_MASK,
+						BF2_KEYLOCK,
+						"Lock Keyboard"
+					},
 					/* data2[5:2] is parsed elsewhere */
-					{"screenblank", 1, (1<<1), (1<<1),
-						"Screen Blank"},
-					{"lockoutreset", 1, (1<<0), (1<<0),
-						"Lock out Resetbuttons"},
+					{
+						"screenblank",
+						BF2_OFFSET,
+						BF2_BLANK_SCREEN_MASK,
+						BF2_BLANK_SCREEN,
+						"Screen Blank"
+					},
+					{
+						"lockoutreset",
+						BF2_OFFSET,
+						BF2_RESET_LOCKOUT_MASK,
+						BF2_RESET_LOCKOUT,
+						"Lock out Reset buttons"
+					},
 					/* data 3 */
-					{"lockout_power", 2, (1<<7), (1<<7),
-						"Lock out (power off/sleep request) via Power Button"},
-					{"verbose=default", 2, (3<<5), (0<<5),
-						"Request quiet BIOS display"},
-					{"verbose=no", 2, (3<<5), (1<<5),
-						"Request quiet BIOS display"},
-					{"verbose=yes", 2, (3<<5), (2<<5),
-						"Request verbose BIOS display"},
-					{"force_pet", 2, (1<<4), (1<<4),
-						"Force progress event traps"},
-					{"upw_bypass", 2, (1<<3), (1<<3),
-						"User password bypass"},
-					{"lockout_sleep", 2, (1<<2), (1<<2),
-						"Log Out Sleep Button"},
-					{"cons_redirect=default", 2, (3<<0), (0<<0),
-						"Console redirection occurs per BIOS configuration setting"},
-					{"cons_redirect=skip", 2, (3<<0), (1<<0),
-						"Suppress (skip) console redirection if enabled"},
-					{"cons_redirect=enable", 2, (3<<0), (2<<0),
-						"Suppress (skip) console redirection if enabled"},
+					{
+						"lockout_power",
+						BF3_OFFSET,
+						BF3_POWER_LOCKOUT_MASK,
+						BF3_POWER_LOCKOUT,
+						"Lock out (power off/sleep "
+							"request) via Power Button"
+					},
+					{
+						"verbose=default",
+						BF3_OFFSET,
+						BF3_VERBOSITY_MASK,
+						BF3_VERBOSITY_DEFAULT,
+						"Request quiet BIOS display"
+					},
+					{
+						"verbose=no",
+						BF3_OFFSET,
+						BF3_VERBOSITY_MASK,
+						BF3_VERBOSITY_QUIET,
+						"Request quiet BIOS display"
+					},
+					{
+						"verbose=yes",
+						BF3_OFFSET,
+						BF3_VERBOSITY_MASK,
+						BF3_VERBOSITY_VERBOSE,
+						"Request verbose BIOS display"
+					},
+					{
+						"force_pet",
+						BF3_OFFSET,
+						BF3_EVENT_TRAPS_MASK,
+						BF3_EVENT_TRAPS,
+						"Force progress event traps"
+					},
+					{
+						"upw_bypass",
+						BF3_OFFSET,
+						BF3_PASSWD_BYPASS_MASK,
+						BF3_PASSWD_BYPASS,
+						"User password bypass"
+					},
+					{
+						"lockout_sleep",
+						BF3_OFFSET,
+						BF3_SLEEP_LOCKOUT_MASK,
+						BF3_SLEEP_LOCKOUT,
+						"Log Out Sleep Button"
+					},
+					{
+						"cons_redirect=default",
+						BF3_OFFSET,
+						BF3_CONSOLE_REDIR_MASK,
+						BF3_CONSOLE_REDIR_DEFAULT,
+						"Console redirection occurs per "
+							"BIOS configuration setting"
+					},
+					{
+						"cons_redirect=skip",
+						BF3_OFFSET,
+						BF3_CONSOLE_REDIR_MASK,
+						BF3_CONSOLE_REDIR_SUPPRESS,
+						"Suppress (skip) console "
+							"redirection if enabled"
+					},
+					{
+						"cons_redirect=enable",
+						BF3_OFFSET,
+						BF3_CONSOLE_REDIR_MASK,
+						BF3_CONSOLE_REDIR_ENABLE,
+						"Suppress (skip) console "
+							"redirection if enabled"
+					},
 					/* data 4 */
 					/* data4[7:4] reserved */
 					/* data4[3] BIOS Shared Mode Override, not implemented here */
@@ -1757,7 +2010,7 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 					/* data5 reserved */
 
 					{NULL}	/* End marker */
-			}, *op;
+				};
 
 			memset(&flags[0], 0, sizeof(flags));
 			token = strtok_r(argv[2] + 8, ",", &saveptr);
@@ -1768,8 +2021,8 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 				}
 				for (op = options; op->name; ++op) {
 					if (strcmp(token, op->name) == 0) {
-						flags[op->i] &= op->mask;
-						flags[op->i] |= op->value;
+						flags[op->offset] &= ~(op->mask);
+						flags[op->offset] |= op->value;
 						break;
 					}
 				}

--- a/lib/ipmi_chassis.c
+++ b/lib/ipmi_chassis.c
@@ -255,7 +255,7 @@ ipmi_chassis_identify(struct ipmi_intf * intf, char * arg)
 	req.msg.cmd = 0x4;
 
 	if (arg) {
-		if (strncmp(arg, "force", 5) == 0) {
+		if (!strcmp(arg, "force")) {
 			identify_data.force_on = 1;
 		} else {
 			if ( (rc = str2uchar(arg, &identify_data.interval)) != 0) {
@@ -1273,29 +1273,43 @@ ipmi_chassis_set_bootdev(struct ipmi_intf * intf, char * arg, uint8_t *iflags)
 
 	if (!arg)
 		flags[1] |= 0x00;
-	else if (strncmp(arg, "none", 4) == 0)
+	else if (!strcmp(arg, "none"))
 		flags[1] |= 0x00;
-	else if (strncmp(arg, "pxe", 3) == 0 ||
-		strncmp(arg, "force_pxe", 9) == 0)
+	else if (!strcmp(arg, "pxe") ||
+		!strcmp(arg, "force_pxe"))
+	{
 		flags[1] |= 0x04;
-	else if (strncmp(arg, "disk", 4) == 0 ||
-		strncmp(arg, "force_disk", 10) == 0)
+	}
+	else if (!strcmp(arg, "disk") ||
+		!strcmp(arg, "force_disk"))
+	{
 		flags[1] |= 0x08;
-	else if (strncmp(arg, "safe", 4) == 0 ||
-		strncmp(arg, "force_safe", 10) == 0)
+	}
+	else if (!strcmp(arg, "safe") ||
+		!strcmp(arg, "force_safe"))
+	{
 		flags[1] |= 0x0c;
-	else if (strncmp(arg, "diag", 4) == 0 ||
-		strncmp(arg, "force_diag", 10) == 0)
+	}
+	else if (!strcmp(arg, "diag") ||
+		!strcmp(arg, "force_diag"))
+	{
 		flags[1] |= 0x10;
-	else if (strncmp(arg, "cdrom", 5) == 0 ||
-		strncmp(arg, "force_cdrom", 11) == 0)
+	}
+	else if (!strcmp(arg, "cdrom") ||
+		!strcmp(arg, "force_cdrom"))
+	{
 		flags[1] |= 0x14;
-	else if (strncmp(arg, "floppy", 6) == 0 ||
-		strncmp(arg, "force_floppy", 12) == 0)
+	}
+	else if (!strcmp(arg, "floppy") ||
+		!strcmp(arg, "force_floppy"))
+	{
 		flags[1] |= 0x3c;
-	else if (strncmp(arg, "bios", 4) == 0 ||
-		strncmp(arg, "force_bios", 10) == 0)
+	}
+	else if (!strcmp(arg, "bios") ||
+		!strcmp(arg, "force_bios"))
+	{
 		flags[1] |= 0x18;
+	}
 	else {
 		lprintf(LOG_ERR, "Invalid argument: %s", arg);
 		rc = -1;
@@ -1666,25 +1680,25 @@ ipmi_power_main(struct ipmi_intf * intf, int argc, char ** argv)
 	int rc = 0;
 	uint8_t ctl = 0;
 
-	if ((argc < 1) || (strncmp(argv[0], "help", 4) == 0)) {
+	if (argc < 1 || !strcmp(argv[0], "help")) {
 		lprintf(LOG_NOTICE, "chassis power Commands: status, on, off, cycle, reset, diag, soft");
 		return 0;
 	}
-	if (strncmp(argv[0], "status", 6) == 0) {
+	if (!strcmp(argv[0], "status")) {
 		rc = ipmi_chassis_print_power_status(intf);
 		return rc;
 	}
-	if ((strncmp(argv[0], "up", 2) == 0) || (strncmp(argv[0], "on", 2) == 0))
+	if (!strcmp(argv[0], "up") || !strcmp(argv[0], "on"))
 		ctl = IPMI_CHASSIS_CTL_POWER_UP;
-	else if ((strncmp(argv[0], "down", 4) == 0) || (strncmp(argv[0], "off", 3) == 0))
+	else if (!strcmp(argv[0], "down") || !strcmp(argv[0], "off"))
 		ctl = IPMI_CHASSIS_CTL_POWER_DOWN;
-	else if (strncmp(argv[0], "cycle", 5) == 0)
+	else if (!strcmp(argv[0], "cycle"))
 		ctl = IPMI_CHASSIS_CTL_POWER_CYCLE;
-	else if (strncmp(argv[0], "reset", 5) == 0)
+	else if (!strcmp(argv[0], "reset"))
 		ctl = IPMI_CHASSIS_CTL_HARD_RESET;
-	else if (strncmp(argv[0], "diag", 4) == 0)
+	else if (!strcmp(argv[0], "diag"))
 		ctl = IPMI_CHASSIS_CTL_PULSE_DIAG;
-	else if ((strncmp(argv[0], "acpi", 4) == 0) || (strncmp(argv[0], "soft", 4) == 0))
+	else if (!strcmp(argv[0], "acpi") || !strcmp(argv[0], "soft"))
 		ctl = IPMI_CHASSIS_CTL_ACPI_SOFT;
 	else {
 		lprintf(LOG_ERR, "Invalid chassis power command: %s", argv[0]);
@@ -1919,42 +1933,51 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 {
 	int rc = -1;
 
-	if ((argc == 0) || (strncmp(argv[0], "help", 4) == 0)) {
+	if (!argc || !strcmp(argv[0], "help")) {
 		lprintf(LOG_NOTICE, "Chassis Commands:\n"
 		                    "  status, power, policy, restart_cause\n"
 		                    "  poh, identify, selftest,\n"
 		                    "  bootdev, bootparam, bootmbox");
 	}
-	else if (strncmp(argv[0], "status", 6) == 0) {
+	else if (!strcmp(argv[0], "status")) {
 		rc = ipmi_chassis_status(intf);
 	}
-	else if (strncmp(argv[0], "selftest", 8) == 0) {
+	else if (!strcmp(argv[0], "selftest")) {
 		rc = ipmi_chassis_selftest(intf);
 	}
-	else if (strncmp(argv[0], "power", 5) == 0) {
+	else if (!strcmp(argv[0], "power")) {
 		uint8_t ctl = 0;
 
-		if ((argc < 2) || (strncmp(argv[1], "help", 4) == 0)) {
+		if (argc < 2 || !strcmp(argv[1], "help")) {
 			lprintf(LOG_NOTICE, "chassis power Commands: status, on, off, cycle, reset, diag, soft");
 			rc = 0;
 			goto out;
 		}
-		if (strncmp(argv[1], "status", 6) == 0) {
+		if (!strcmp(argv[1], "status")) {
 			rc = ipmi_chassis_print_power_status(intf);
 			goto out;
 		}
-		if ((strncmp(argv[1], "up", 2) == 0) || (strncmp(argv[1], "on", 2) == 0))
+		if (!strcmp(argv[1], "up") ||
+		    !strcmp(argv[1], "on"))
+		{
 			ctl = IPMI_CHASSIS_CTL_POWER_UP;
-		else if ((strncmp(argv[1], "down", 4) == 0) || (strncmp(argv[1], "off", 3) == 0))
+		}
+		else if (!strcmp(argv[1], "down") ||
+		         !strcmp(argv[1], "off"))
+		{
 			ctl = IPMI_CHASSIS_CTL_POWER_DOWN;
-		else if (strncmp(argv[1], "cycle", 5) == 0)
+		}
+		else if (!strcmp(argv[1], "cycle"))
 			ctl = IPMI_CHASSIS_CTL_POWER_CYCLE;
-		else if (strncmp(argv[1], "reset", 5) == 0)
+		else if (!strcmp(argv[1], "reset"))
 			ctl = IPMI_CHASSIS_CTL_HARD_RESET;
-		else if (strncmp(argv[1], "diag", 4) == 0)
+		else if (!strcmp(argv[1], "diag"))
 			ctl = IPMI_CHASSIS_CTL_PULSE_DIAG;
-		else if ((strncmp(argv[1], "acpi", 4) == 0) || (strncmp(argv[1], "soft", 4) == 0))
+		else if (!strcmp(argv[1], "acpi") ||
+		         !strcmp(argv[1], "soft"))
+		{
 			ctl = IPMI_CHASSIS_CTL_ACPI_SOFT;
+		}
 		else {
 			lprintf(LOG_ERR, "Invalid chassis power command: %s", argv[1]);
 			goto out;
@@ -1962,11 +1985,11 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 
 		rc = ipmi_chassis_power_control(intf, ctl);
 	}
-	else if (strncmp(argv[0], "identify", 8) == 0) {
+	else if (!strcmp(argv[0], "identify")) {
 		if (argc < 2) {
 			rc = ipmi_chassis_identify(intf, NULL);
 		}
-		else if (strncmp(argv[1], "help", 4) == 0) {
+		else if (!strcmp(argv[1], "help")) {
 			lprintf(LOG_NOTICE, "chassis identify <interval>");
 			lprintf(LOG_NOTICE, "                 default is 15 seconds");
 			lprintf(LOG_NOTICE, "                 0 to turn off");
@@ -1975,14 +1998,14 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 			rc = ipmi_chassis_identify(intf, argv[1]);
 		}
 	}
-	else if (strncmp(argv[0], "poh", 3) == 0) {
+	else if (!strcmp(argv[0], "poh")) {
 		rc = ipmi_chassis_poh(intf);
 	}
-	else if (strncmp(argv[0], "restart_cause", 13) == 0) {
+	else if (!strcmp(argv[0], "restart_cause")) {
 		rc = ipmi_chassis_restart_cause(intf);
 	}
-	else if (strncmp(argv[0], "policy", 4) == 0) {
-		if ((argc < 2) || (strncmp(argv[1], "help", 4) == 0)) {
+	else if (!strcmp(argv[0], "policy")) {
+		if (argc < 2 || !strcmp(argv[1], "help")) {
 			lprintf(LOG_NOTICE, "chassis policy <state>");
 			lprintf(LOG_NOTICE, "   list        : return supported policies");
 			lprintf(LOG_NOTICE, "   always-on   : turn on when power is restored");
@@ -1990,13 +2013,13 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 			lprintf(LOG_NOTICE, "   always-off  : stay off after power is restored");
 		} else {
 			uint8_t ctl;
-			if (strncmp(argv[1], "list", 4) == 0)
+			if (!strcmp(argv[1], "list"))
 				ctl = IPMI_CHASSIS_POLICY_NO_CHANGE;
-			else if (strncmp(argv[1], "always-on", 9) == 0)
+			else if (!strcmp(argv[1], "always-on"))
 				ctl = IPMI_CHASSIS_POLICY_ALWAYS_ON;
-			else if (strncmp(argv[1], "previous", 8) == 0)
+			else if (!strcmp(argv[1], "previous"))
 				ctl = IPMI_CHASSIS_POLICY_PREVIOUS;
-			else if (strncmp(argv[1], "always-off", 10) == 0)
+			else if (!strcmp(argv[1], "always-off"))
 				ctl = IPMI_CHASSIS_POLICY_ALWAYS_OFF;
 			else {
 				lprintf(LOG_ERR, "Invalid chassis policy: %s", argv[1]);
@@ -2005,22 +2028,22 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 			rc = ipmi_chassis_power_policy(intf, ctl);
 		}
 	}
-	else if (strncmp(argv[0], "bootparam", 9) == 0) {
-		if ((argc < 3) || (strncmp(argv[1], "help", 4) == 0)) {
+	else if (!strcmp(argv[0], "bootparam")) {
+		if (argc < 3 || !strcmp(argv[1], "help")) {
 			lprintf(LOG_NOTICE, "bootparam get <param #>");
 		    ipmi_chassis_set_bootflag_help();
 		}
 		else {
-			if (strncmp(argv[1], "get", 3) == 0) {
+			if (!strcmp(argv[1], "get")) {
 				rc = ipmi_chassis_get_bootparam(intf,
 								argc - 2,
 								argv + 2,
 								0);
 			}
-			else if (strncmp(argv[1], "set", 3) == 0) {
+			else if (!strcmp(argv[1], "set")) {
 			    unsigned char set_flag=0;
 			    unsigned char clr_flag=0;
-				if (strncmp(argv[2], "help", 4) == 0  ||
+				if (!strcmp(argv[2], "help")  ||
 						argc < 4 || (argc >= 4 &&
 							 strncmp(argv[2], "bootflag", 8) != 0)) {
 					ipmi_chassis_set_bootflag_help();
@@ -2038,8 +2061,8 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 				lprintf(LOG_NOTICE, "bootparam get|set <option> [value ...]");
 		}
 	}
-	else if (strncmp(argv[0], "bootdev", 7) == 0) {
-		if ((argc < 2) || (strncmp(argv[1], "help", 4) == 0)) {
+	else if (!strcmp(argv[0], "bootdev")) {
+		if (argc < 2 || !strcmp(argv[1], "help")) {
 			lprintf(LOG_NOTICE, "bootdev <device> [clear-cmos=yes|no]");
 			lprintf(LOG_NOTICE, "bootdev <device> [options=help,...]");
 			lprintf(LOG_NOTICE, "  none  : Do not change boot device order");

--- a/lib/ipmi_chassis.c
+++ b/lib/ipmi_chassis.c
@@ -1976,7 +1976,7 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 						BF3_OFFSET,
 						BF3_SLEEP_LOCKOUT_MASK,
 						BF3_SLEEP_LOCKOUT,
-						"Log Out Sleep Button"
+						"Lock out the Sleep button"
 					},
 					{
 						"cons_redirect=default",
@@ -1999,8 +1999,8 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 						BF3_OFFSET,
 						BF3_CONSOLE_REDIR_MASK,
 						BF3_CONSOLE_REDIR_ENABLE,
-						"Suppress (skip) console "
-							"redirection if enabled"
+						"Request console redirection "
+							"be enabled"
 					},
 					/* data 4 */
 					/* data4[7:4] reserved */
@@ -2035,9 +2035,11 @@ ipmi_chassis_main(struct ipmi_intf * intf, int argc, char ** argv)
 			}
 			if (optionError) {
 				lprintf(LOG_NOTICE, "Legal options settings are:");
-				lprintf(LOG_NOTICE, "\thelp:\tprint this message");
+				lprintf(LOG_NOTICE, "  %-22s: %s",
+				                    "help",
+				                    "print this message");
 				for (op = options; op->name; ++op) {
-					lprintf(LOG_NOTICE, "\t%s:\t%s", op->name, op->desc);
+					lprintf(LOG_NOTICE, "  %-22s: %s", op->name, op->desc);
 				}
 				return (-1);
 			}


### PR DESCRIPTION
This resolves #163 and also cleans up `chassis bootparam get` decoding and `chassis bootdev options=...` parsing.

Please read individual commit messages.