### PR TITLE
Docs: Add info on packages to install on Ubuntu 16.04 and Fedora 31

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -22,6 +22,12 @@ project is tested automatically to build cleanly for the following
    - Ubuntu 16.04 Xenial
    - MacOS X 10.14 (Xcode 10.2)
 
+   For Ubuntu 16.04 it is recommended to do the following before building:
+$ sudo apt install automake gcc git libncurses-dev libreadline-dev libssl-dev libsystemd-dev libtool make wget
+
+   For Fedora 31 it is recommended to do the following before building:
+$ sudo dnf install automake gcc git libtool make ncurses-devel openssl-devel readline-devel systemd-devel wget
+
 Basic Installation
 ==================
 


### PR DESCRIPTION
Add some documenation on packages to install on Ubuntu 16.04 before
building the software.

This will make it easier for people who are building ipmitool as they
won't need to figure out all the package dependencies on their own.