### PR TITLE
Docs: Add info on the 'system_fw_version' option

### DIFF
--- a/doc/ipmitool.1.in
+++ b/doc/ipmitool.1.in
@@ -2189,6 +2189,8 @@ Stores system info string to bmc for given argument
 Possible arguments are:
 .RS
 .TP
+\fIsystem_fw_version\fP   System firmware (e.g. BIOS) version
+.TP
 \fIprimary_os_name\fP     Primary Operating System Name
 .TP
 \fIos_name\fP             Operating System Name


### PR DESCRIPTION
Add info about the 'system_fw_version' option in the command 'bmc
getsysinfo' to the manpage.