### PR TITLE
Cleanup/drop ncurses

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -23,10 +23,10 @@ project is tested automatically to build cleanly for the following
    - MacOS X 10.14 (Xcode 10.2)
 
    For Ubuntu 16.04 it is recommended to do the following before building:
-$ sudo apt install automake gcc git libncurses-dev libreadline-dev libssl-dev libsystemd-dev libtool make wget
+$ sudo apt install automake gcc git libreadline-dev libssl-dev libsystemd-dev libtool make wget
 
    For Fedora 31 it is recommended to do the following before building:
-$ sudo dnf install automake gcc git libtool make ncurses-devel openssl-devel readline-devel systemd-devel wget
+$ sudo dnf install automake gcc git libtool make openssl-devel readline-devel systemd-devel wget
 
 Basic Installation
 ==================

--- a/configure.ac
+++ b/configure.ac
@@ -624,13 +624,7 @@ AC_ARG_ENABLE([ipmishell],
 
 dnl check for readline library to enable ipmi shell
 if test "x$xenable_ipmishell" = "xyes"; then
-	AC_SEARCH_LIBS([tgetent], [tinfo ncurses curses readline termcap])
-	AC_SEARCH_LIBS([initscr], [ncurses curses], [have_curses=yes])
 	AC_SEARCH_LIBS([readline], [readline edit], [have_readline=yes])
-	if test "x$have_curses" != "xyes"; then
-		AC_MSG_ERROR([** Unable to find curses required by ipmishell.])
-		xenable_ipmishell=no
-	fi
 	if test "x$have_readline" != "xyes"; then
 		AC_MSG_ERROR([** Unable to find readline required by ipmishell.])
 		xenable_ipmishell=no

--- a/configure.ac
+++ b/configure.ac
@@ -616,30 +616,24 @@ fi
 
 AC_SUBST(IPMITOOL_INTF_LIB)
 
-if test "x$xenable_ipmishell" = "xyes"; then
-	AC_SEARCH_LIBS([tgetent], [tinfo ncurses curses readline termcap])
-	AC_SEARCH_LIBS([initscr], [ncurses curses], [have_curses=yes])
-	AC_SEARCH_LIBS([readline], [readline edit], [have_readline=yes])
-	if test "x$have_curses" != "xyes" || test "x$have_readline" != "xyes"; then
-		xenable_ipmishell=no
-	fi
-fi
-
-dnl check for readline library to enable ipmi shell
 AC_ARG_ENABLE([ipmishell],
 	[AC_HELP_STRING([--enable-ipmishell],
 			[enable IPMI shell interface [default=auto]])],
 	[xenable_ipmishell=$enableval],
 	[])
+
+dnl check for readline library to enable ipmi shell
 if test "x$xenable_ipmishell" = "xyes"; then
 	AC_SEARCH_LIBS([tgetent], [tinfo ncurses curses readline termcap])
 	AC_SEARCH_LIBS([initscr], [ncurses curses], [have_curses=yes])
 	AC_SEARCH_LIBS([readline], [readline edit], [have_readline=yes])
 	if test "x$have_curses" != "xyes"; then
 		AC_MSG_ERROR([** Unable to find curses required by ipmishell.])
+		xenable_ipmishell=no
 	fi
 	if test "x$have_readline" != "xyes"; then
 		AC_MSG_ERROR([** Unable to find readline required by ipmishell.])
+		xenable_ipmishell=no
 	fi
 	AC_DEFINE(HAVE_READLINE, [1], [Define to 1 if readline present.])
 fi


### PR DESCRIPTION
As explained in the [OpenBMC mailing list](https://lists.ozlabs.org/pipermail/openbmc/2019-November/019678.html), the ncurses dependency is superfluous and may safely be dropped.