### PR TITLE
read_fru_area: fix memset() parameters

### DIFF
--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -679,11 +679,11 @@ read_fru_area(struct ipmi_intf * intf, struct fru_info *fru, uint8_t id,
 
 	finish = offset + length;
 	if (finish > fru->size) {
-		memset(frubuf + fru->size, 0, length - fru->size);
-		finish = fru->size;
+		memset(frubuf + fru->size - offset, 0, finish - fru->size);
 		lprintf(LOG_NOTICE, "Read FRU Area length %d too large, "
 			"Adjusting to %d",
-			offset + length, finish - offset);
+			finish - offset, fru->size - offset);
+		finish = fru->size;
 		length = finish - offset;
 	}
 
@@ -1182,6 +1182,8 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 	/* read enough to check length field */
 	if (read_fru_area(intf, fru, id, offset, 2, tmp) == 0) {
 		fru_len = 8 * tmp[1];
+	} else {
+		lprintf(LOG_ERR, "Can not get Product Area Length");
 	}
 
 	if (fru_len == 0) {


### PR DESCRIPTION
Current memset parameters are calculated in the assumption
that we use the buffer for whole FRU. Whereas we use individual
buffers for each area that are smaller than whole FRU size.
That may lead to attempt to memset beyond allocated buffer.
Also: add comment to fail path in fru_area_print_product().