### PR TITLE
harden ipmi_sdr_get_record() against bad records

### DIFF
--- a/lib/ipmi_sdr.c
+++ b/lib/ipmi_sdr.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012 Hewlett-Packard Development Company, L.P.
+ * Copyright 2020 Joyent, Inc.
  *
  * Based on code from
  * Copyright (c) 2003 Sun Microsystems, Inc.  All Rights Reserved.
@@ -3159,7 +3160,8 @@ ipmi_sdr_get_record(struct ipmi_intf * intf, struct sdr_get_rs * header,
 			sdr_rq.length, sdr_rq.offset);
 
 		rsp = intf->sendrecv(intf, &req);
-		if (!rsp) {
+
+		if (!rsp || rsp->ccode == 0xca) {
 		    sdr_max_read_len = sdr_rq.length - 1;
 		    if (sdr_max_read_len > 0) {
 			/* no response may happen if requests are bridged
@@ -3170,14 +3172,7 @@ ipmi_sdr_get_record(struct ipmi_intf * intf, struct sdr_get_rs * header,
 			data = NULL;
 			return NULL;
 		    }
-		}
-
-		switch (rsp->ccode) {
-		case 0xca:
-			/* read too many bytes at once */
-			sdr_max_read_len = sdr_rq.length - 1;
-			continue;
-		case 0xc5:
+		} else if (rsp->ccode == 0xc5) {
 			/* lost reservation */
 			lprintf(LOG_DEBUG, "SDR reservation cancelled. "
 				"Sleeping a bit and retrying...");
@@ -3202,7 +3197,7 @@ ipmi_sdr_get_record(struct ipmi_intf * intf, struct sdr_get_rs * header,
 		}
 
 		memcpy(data + i, rsp->data + 2, sdr_rq.length);
-		i += sdr_max_read_len;
+		i += sdr_rq.length;
 	}
 
 	return data;

--- a/lib/ipmi_sdr.c
+++ b/lib/ipmi_sdr.c
@@ -3161,7 +3161,7 @@ ipmi_sdr_get_record(struct ipmi_intf * intf, struct sdr_get_rs * header,
 
 		rsp = intf->sendrecv(intf, &req);
 
-		if (!rsp || rsp->ccode == 0xca) {
+		if (!rsp || rsp->ccode == IPMI_CC_CANT_RET_NUM_REQ_BYTES) {
 		    sdr_max_read_len = sdr_rq.length - 1;
 		    if (sdr_max_read_len > 0) {
 			/* no response may happen if requests are bridged
@@ -3172,7 +3172,7 @@ ipmi_sdr_get_record(struct ipmi_intf * intf, struct sdr_get_rs * header,
 			data = NULL;
 			return NULL;
 		    }
-		} else if (rsp->ccode == 0xc5) {
+		} else if (rsp->ccode == IPMI_CC_RES_CANCELED) {
 			/* lost reservation */
 			lprintf(LOG_DEBUG, "SDR reservation cancelled. "
 				"Sleeping a bit and retrying...");


### PR DESCRIPTION
On one of our production systems (Supermicro X9DRD-7LN4F based), ipmitool sensor was occasionally crashing. This was due to it sometimes returning a junk SDR of the form:

```
SDR record ID   : 0x008a
SDR record id mismatch: 0x000a
SDR record type : 0x00
SDR record next : 0x0000
SDR record bytes: 100
```

or something similar. In this case, when we request the SDR data, we're getting back 0xca. However, ipmi_sdr_get_record() can underflow sdr_max_read_len to a negative value in this case. Harden the code for this.

Also, fix the addition of i to use the correct amount: it doesn't actually matter, since we'll check for i < len in the loop condition, but still.