### PR TITLE
configure: Fix compatibility with non-bash systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -689,25 +689,24 @@ dnl allow for a default interface to be set on configure
 AC_ARG_VAR(DEFAULT_INTF, [Set the default interface to use (default='open' if available, 'lan' otherwise)])
 
 dnl set the default value for the default interface environment variable
-if test "x${DEFAULT_INTF}" == "x"; then
+if test "x${DEFAULT_INTF}" = "x"; then
 	echo "DEFAULT_INTF not found in environment; setting to ${DEFAULT_INTF_NO_ENV}"
 	DEFAULT_INTF=${DEFAULT_INTF_NO_ENV}
 fi
 
-xdefault_intf_is_enabled="xenable_intf_${DEFAULT_INTF}"
-if test "x${!xdefault_intf_is_enabled}" != "xyes"; then
-	AC_MSG_ERROR([** Cannot set ${DEFAULT_INTF} as default; ${DEFAULT_INTF} is not enabled. :${!xdefault_intf_is_enabled}:])
+if test "x"`eval "echo \\\${xenable_intf_${DEFAULT_INTF}}"` != "xyes"; then
+	AC_MSG_ERROR([** Cannot set ${DEFAULT_INTF} as default; intf-${DEFAULT_INTF} is not enabled.])
 fi
 
 AC_ARG_VAR(IANADIR, [Configure the path to IANA PEN dictionary (default=DATAROOTDIR/misc)])
 AC_ARG_VAR(IANAUSERDIR, [Configure the path to IANA PEN dictionary wihtin the user's HOME directory (default=.local/usr/share/misc)])
 
-if test "x${IANADIR}" == "x"; then
+if test "x${IANADIR}" = "x"; then
 	echo Set IANA PEN dictionary search path to ${datarootdir}/misc
 	IANADIR="${datarootdir}/misc"
 fi
 
-if test "x${IANAUSERDIR}" == "x"; then
+if test "x${IANAUSERDIR}" = "x"; then
 	IANAUSERDIR=".local/usr/share/misc"
 	echo Set user\'s IANA PEN dictionary search path to ${IANAUSERDIR}
 fi


### PR DESCRIPTION
Remove a bashims from configure to make build compatible
with systems without bash.

Resolves ipmitool/ipmitool#205

Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>