### PR TITLE
doc, ci: Fix an error in package name for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
                 libncurses-devel `
                 libreadline-devel `
                 libssl-devel `
-                unix2dos `
+                dos2unix `
                 wget
         echo "::add-path::C:/tools/cygwin/bin"
         echo "::add-path::C:/tools/cygwin/usr/bin"

--- a/INSTALL
+++ b/INSTALL
@@ -55,7 +55,7 @@ and do the following using PowerShell:
    PS C:\ipmitool> choco install cyg-get -y
    PS C:\ipmitool> cyg-get gcc-g++ make automake autoconf `
    # m4 libtool libncurses-devel libreadline-devel libssl-devel `
-   # unix2dos wget
+   # dos2unix wget
    PS C:\ipmitool> $env:path="C:\tools\cygwin\usr\bin;$env:path"
    PS C:\ipmitool> $env:path="C:\tools\cygwin\bin;$env:path"
    PS C:\ipmitool> dos2unix bootstrap configure.ac csv-revision


### PR DESCRIPTION
it's dos2unix, not unix2dos

Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>