### PR TITLE
Add version info to debug output

### DIFF
--- a/lib/ipmi_main.c
+++ b/lib/ipmi_main.c
@@ -358,11 +358,15 @@ ipmi_main(int argc, char ** argv,
 	/* Set program locale according to system settings */
 	setlocale(LC_ALL, "");
 
+
 	/* save program name */
 	progname = strrchr(argv[0], '/');
 	progname = ((!progname) ? argv[0] : progname+1);
 	signal(SIGINT, ipmi_catch_sigint);
 	memset(kgkey, 0, sizeof(kgkey));
+
+	/* setup log */
+	log_init(progname, 0, 0);
 
 	while ((argflag = getopt(argc, (char **)argv, OPTION_STRING)) != -1)
 	{
@@ -443,7 +447,11 @@ ipmi_main(int argc, char ** argv,
 			break;
 #endif /* IPMI_INTF_LANPLUS */
 		case 'v':
-			verbose++;
+			log_level_set(++verbose);
+			if (verbose == 2) {
+				/* add version info to debug output */
+				lprintf(LOG_DEBUG, "%s version %s\n", progname, VERSION);
+			}
 			break;
 		case 'c':
 			csv_output = 1;
@@ -843,9 +851,6 @@ ipmi_main(int argc, char ** argv,
 		lprintf(LOG_ERR, "Error loading interface %s", intfname);
 		goto out_free;
 	}
-
-	/* setup log */
-	log_init(progname, 0, verbose);
 
 	/* load the IANA PEN registry */
 	if (ipmi_oem_info_init()) {

--- a/lib/ipmi_strings.c
+++ b/lib/ipmi_strings.c
@@ -1631,6 +1631,7 @@ oem_info_init_from_list(oem_valstr_list_t *oemlist, size_t count)
 	size_t tail_entries = ARRAY_SIZE(ipmi_oem_info_tail) - 1;
 	static oem_valstr_list_t *item;
 	bool rc = false;
+	int oemlist_debug = LOG_DEBUG + 4; /* Require six -v options */
 
 	/* Include static entries and the terminator */
 	count += head_entries + tail_entries + 1;
@@ -1653,7 +1654,7 @@ oem_info_init_from_list(oem_valstr_list_t *oemlist, size_t count)
 		goto out;
 	}
 
-	lprintf(LOG_DEBUG + 3, "  Allocating %6zu entries", count);
+	lprintf(oemlist_debug, "  Allocating %6zu entries", count);
 
     /* Add a terminator at the very end */
 	--count;
@@ -1665,7 +1666,7 @@ oem_info_init_from_list(oem_valstr_list_t *oemlist, size_t count)
 		((struct valstr *)ipmi_oem_info)[count] = 
 			ipmi_oem_info_tail[tail_entries];
 
-		lprintf(LOG_DEBUG + 3, "  [%6zu] %8d | %s", count,
+		lprintf(oemlist_debug, "  [%6zu] %8d | %s", count,
 		        ipmi_oem_info[count].val, ipmi_oem_info[count].str);
 	}
 
@@ -1675,7 +1676,7 @@ oem_info_init_from_list(oem_valstr_list_t *oemlist, size_t count)
 		((struct valstr *)ipmi_oem_info)[count] =
 			item->valstr;
 
-		lprintf(LOG_DEBUG + 3, "  [%6zu] %8d | %s", count,
+		lprintf(oemlist_debug, "  [%6zu] %8d | %s", count,
 		        ipmi_oem_info[count].val, ipmi_oem_info[count].str);
 
 		item = item->next;
@@ -1686,7 +1687,7 @@ oem_info_init_from_list(oem_valstr_list_t *oemlist, size_t count)
 	while (count < SIZE_MAX && head_entries--) {
 		((struct valstr *)ipmi_oem_info)[count] =
 			ipmi_oem_info_head[head_entries];
-		lprintf(LOG_DEBUG + 3, "  [%6zu] %8d | %s", count,
+		lprintf(oemlist_debug, "  [%6zu] %8d | %s", count,
 		        ipmi_oem_info[count].val, ipmi_oem_info[count].str);
 		--count;
 	}

--- a/lib/log.c
+++ b/lib/log.c
@@ -144,13 +144,8 @@ void log_halt(void)
 	logpriv = NULL;
 }
 
-int log_level_get(void)
+void log_level_set(int verbose)
 {
-	return logpriv->level;
-}
-
-void log_level_set(int level)
-{
-	logpriv->level = level;
+	logpriv->level = verbose + LOG_NOTICE;
 }
 


### PR DESCRIPTION
- Initialize the log at the start of ipmi_main() to allow for proper
  logging at the start;
- Remove the unused log_level_get() function;
- Update log_level_set() to take verbosity instead of log level
  (default verbosity is 0, which is LOG_NOTICE log level),
  use the function to update log level as `-v` is encountered
  in command line;
- Move IANA PEN list debugging to verbosity 6. The list is too long
  to see it in each debug output of verbosity 5 that is used for
  debugging lan/lanplus packets;
- For verbosity >= 2 (that is `-vv`) add the ipmitool version
  information at the start.

Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>