### PR TITLE
Add support for BCD and 6-bit ASCII to ipmitool SDR handling

### DIFF
--- a/include/ipmitool/Makefile.am
+++ b/include/ipmitool/Makefile.am
@@ -39,5 +39,5 @@ noinst_HEADERS = log.h bswap.h hpm2.h helper.h ipmi.h ipmi_cc.h ipmi_intf.h \
 	ipmi_fwum.h ipmi_main.h ipmi_tsol.h ipmi_firewall.h \
 	ipmi_kontronoem.h ipmi_ekanalyzer.h ipmi_gendev.h ipmi_ime.h \
 	ipmi_delloem.h ipmi_dcmi.h ipmi_vita.h ipmi_sel_supermicro.h \
-	ipmi_cfgp.h ipmi_lanp6.h ipmi_quantaoem.h ipmi_time.h
+	ipmi_cfgp.h ipmi_lanp6.h ipmi_quantaoem.h ipmi_time.h ipmi_string.h
 

--- a/include/ipmitool/ipmi_fru.h
+++ b/include/ipmitool/ipmi_fru.h
@@ -622,6 +622,6 @@ typedef struct ipmi_fru_bloc {
 
 int ipmi_fru_main(struct ipmi_intf *intf, int argc, char **argv);
 int ipmi_fru_print(struct ipmi_intf *intf, struct sdr_record_fru_locator *fru);
-char *get_fru_area_str(uint8_t *data, uint32_t *offset);
+char *get_fru_area_str(uint8_t *data, uint32_t *offset, uint32_t section_len);
 
 #endif /* IPMI_FRU_H */

--- a/include/ipmitool/ipmi_sdr.h
+++ b/include/ipmitool/ipmi_sdr.h
@@ -67,6 +67,8 @@ int ipmi_sdr_main(struct ipmi_intf *, int, char **);
 # define __TO_B_EXP(bacc)   (int32_t)(tos32((BSWAP_32(bacc) & 0xf), 4))
 #endif
 
+#define IPMI_SDR_MAX_STR_SIZE 33
+
 enum {
 	ANALOG_SENSOR,
 	DISCRETE_SENSOR,
@@ -465,8 +467,7 @@ struct sdr_record_compact_sensor {
 
 	uint8_t __reserved[3];
 	uint8_t oem;		/* reserved for OEM use */
-	uint8_t id_code;	/* sensor ID string type/length code */
-	uint8_t id_string[16];	/* sensor ID string bytes, only if id_code != 0 */
+	uint8_t raw_id[17];	/* sensor ID string bytes */
 } ATTRIBUTE_PACKING;
 #ifdef HAVE_PRAGMA_PACK
 #pragma pack(0)
@@ -516,8 +517,7 @@ struct sdr_record_eventonly_sensor {
 
 	uint8_t __reserved;
 	uint8_t oem;		/* reserved for OEM use */
-	uint8_t id_code;	/* sensor ID string type/length code */
-	uint8_t id_string[16];	/* sensor ID string bytes, only if id_code != 0 */
+	uint8_t raw_id[17];	/* sensor ID string bytes */
 
 } ATTRIBUTE_PACKING;
 #ifdef HAVE_PRAGMA_PACK
@@ -586,8 +586,7 @@ struct sdr_record_full_sensor {
 	} ATTRIBUTE_PACKING threshold;
 	uint8_t __reserved[2];
 	uint8_t oem;		/* reserved for OEM use */
-	uint8_t id_code;	/* sensor ID string type/length code */
-	uint8_t id_string[16];	/* sensor ID string bytes, only if id_code != 0 */
+	uint8_t raw_id[17];	/* sensor ID string bytes */
 } ATTRIBUTE_PACKING;
 #ifdef HAVE_PRAGMA_PACK
 #pragma pack(0)
@@ -618,8 +617,7 @@ struct sdr_record_mc_locator {
 	uint8_t __reserved4[3];
 	struct entity_id entity;
 	uint8_t oem;
-	uint8_t id_code;
-	uint8_t id_string[16];
+	uint8_t raw_id[17];
 } ATTRIBUTE_PACKING;
 #ifdef HAVE_PRAGMA_PACK
 #pragma pack(0)
@@ -651,8 +649,7 @@ struct sdr_record_fru_locator {
 	uint8_t dev_type_modifier;
 	struct entity_id entity;
 	uint8_t oem;
-	uint8_t id_code;
-	uint8_t id_string[16];
+	uint8_t raw_id[17];
 } ATTRIBUTE_PACKING;
 #ifdef HAVE_PRAGMA_PACK
 #pragma pack(0)
@@ -685,8 +682,7 @@ struct sdr_record_generic_locator {
 	uint8_t dev_type_modifier;
 	struct entity_id entity;
 	uint8_t oem;
-	uint8_t id_code;
-	uint8_t id_string[16];
+	uint8_t raw_id[17];
 } ATTRIBUTE_PACKING;
 #ifdef HAVE_PRAGMA_PACK
 #pragma pack(0)
@@ -800,7 +796,7 @@ struct sdr_record_list {
 #define SENSOR_TYPE_MAX 0x2C
 
 struct sensor_reading {
-	char		s_id[17];		/* name of the sensor */
+	char		s_id[IPMI_SDR_MAX_STR_SIZE]; /* name of the sensor */
 	struct sdr_record_full_sensor    *full;
 	struct sdr_record_compact_sensor *compact;
 	uint8_t		s_reading_valid;	/* read value valididity */
@@ -926,5 +922,11 @@ int ipmi_sdr_print_sensor_event_enable(struct ipmi_intf *intf,
 				       uint8_t sensor_num, uint8_t sensor_type,
 				       uint8_t event_type, int numeric_fmt,
 				       uint8_t target, uint8_t lun, uint8_t channel);
+
+/*
+ * raw_id must be 17 bytes, and output must point to something at least
+ * IPMI_SDR_MAX_STR_SIZE long.
+ */
+extern void ipmi_get_sdr_string(uint8_t *raw_id, char *output);
 
 #endif				/* IPMI_SDR_H */

--- a/include/ipmitool/ipmi_string.h
+++ b/include/ipmitool/ipmi_string.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 MontaVista Software, LLC.  All Rights Reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * Redistribution of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 
+ * Redistribution in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * Neither the name of MontaVista Software, Inc. or the names of
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * 
+ * This software is provided "AS IS," without a warranty of any kind.
+ * ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND WARRANTIES,
+ * INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY EXCLUDED.
+ * MONTAVISTA SOFTWARE, LLC. ("MONTAVISTA") AND ITS LICENSORS SHALL
+ * NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF
+ * USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+ * IN NO EVENT WILL MONTAVISTA OR ITS LICENSORS BE LIABLE FOR ANY LOST
+ * REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL,
+ * CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND
+ * REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF THE USE OF OR
+ * INABILITY TO USE THIS SOFTWARE, EVEN IF MONTAVISTA HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGES.
+ */
+
+#ifndef IPMI_STRING_H
+#define IPMI_STRING_H
+
+#include <stdint.h>
+
+enum ipmi_str_type_e {
+	IPMI_ASCII_STR		= 0,
+	IPMI_UNICODE_STR	= 1,
+	IPMI_BINARY_STR		= 2,
+};
+
+#define IPMI_STR_SDR_SEMANTICS	0
+#define IPMI_STR_FRU_SEMANTICS	1
+
+extern unsigned int ipmi_get_device_string(uint8_t ** const pinput,
+					   unsigned int in_len,
+					   int semantics, int force_unicode,
+					   enum ipmi_str_type_e *stype,
+					   unsigned int max_out_len,
+					   char *output);
+
+#endif /* IPMI_STRING_H */

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -41,7 +41,8 @@ libipmitool_la_SOURCES	= helper.c ipmi_sdr.c ipmi_sel.c ipmi_sol.c ipmi_pef.c \
 				  ipmi_main.c ipmi_tsol.c ipmi_firewall.c ipmi_kontronoem.c        \
 				  ipmi_hpmfwupg.c ipmi_sdradd.c ipmi_ekanalyzer.c ipmi_gendev.c    \
 				  ipmi_ime.c ipmi_delloem.c ipmi_dcmi.c hpm2.c ipmi_vita.c \
-				  ipmi_lanp6.c ipmi_cfgp.c ipmi_quantaoem.c ipmi_time.c
+				  ipmi_lanp6.c ipmi_cfgp.c ipmi_quantaoem.c ipmi_time.c \
+				  ipmi_string.c
 
 libipmitool_la_LDFLAGS		= -export-dynamic
 libipmitool_la_LIBADD		= -lm

--- a/lib/ipmi_ekanalyzer.c
+++ b/lib/ipmi_ekanalyzer.c
@@ -2752,7 +2752,8 @@ ipmi_ek_display_board_info_area(FILE *input_file, char *board_type,
 		printf("%s type: 0x%02x\n", board_type, len);
 		printf("%s: ", board_type);
 		i = 0;
-		str = (unsigned char *)get_fru_area_str(data, &i);
+		str = (unsigned char *)get_fru_area_str(data, &i,
+							size_board + 1);
 		printf("%s\n", str);
 		free(str);
 		str = NULL;
@@ -2809,7 +2810,8 @@ ipmi_ek_display_board_info_area(FILE *input_file, char *board_type,
 			}
 			printf("Additional Custom Mfg. Data: ");
 			i = 0;
-			str = (unsigned char *)get_fru_area_str(additional_data, &i);
+			str = (unsigned char *)get_fru_area_str(additional_data, &i,
+								size_board + 1);
 			printf("%s\n", str);
 			free(str);
 			str = NULL;

--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -40,6 +40,7 @@
 #include <ipmitool/ipmi_sdr.h>
 #include <ipmitool/ipmi_strings.h>  /* IANA id strings */
 #include <ipmitool/ipmi_time.h>
+#include <ipmitool/ipmi_string.h>
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -147,100 +148,35 @@ void free_fru_bloc(t_ipmi_fru_bloc *bloc);
 *
 * returns pointer to FRU area string
 */
-char * get_fru_area_str(uint8_t * data, uint32_t * offset)
+char * get_fru_area_str(uint8_t * data, uint32_t * offset, uint32_t section_len)
 {
-	static const char bcd_plus[] = "0123456789 -.:,_";
-	char * str;
-	int len, off, size, i, j, k, typecode, char_idx;
-	union {
-		uint32_t bits;
-		char chars[4];
-	} u;
+	char str[65], *rstr;
+	uint8_t *ptr = data + *offset;
+	unsigned int len, i;
+	enum ipmi_str_type_e stype;
 
-	size = 0;
-	off = *offset;
+	data = ptr;
+	len = ipmi_get_device_string(&ptr, section_len, IPMI_STR_FRU_SEMANTICS,
+				     1, &stype, sizeof(str), str);
 
-	/* bits 6:7 contain format */
-	typecode = ((data[off] & 0xC0) >> 6);
+	*offset += ptr - data;
 
-	// printf("Typecode:%i\n", typecode);
-	/* bits 0:5 contain length */
-	len = data[off++];
-	len &= 0x3f;
-
-	switch (typecode) {
-	case 0:           /* 00b: binary/unspecified */
-	case 1:           /* 01b: BCD plus */
-		/* hex dump or BCD -> 2x length */
-		size = (len * 2);
-		break;
-	case 2:           /* 10b: 6-bit ASCII */
-		/* 4 chars per group of 1-3 bytes */
-		size = (((len * 4 + 2) / 3) & ~3);
-		break;
-	case 3:           /* 11b: 8-bit ASCII */
-		/* no length adjustment */
-		size = len;
-		break;
-	}
-
-	if (size < 1) {
-		*offset = off;
+	str[len] = '\0';
+	if (len == 0)
 		return NULL;
-	}
-	str = malloc(size+1);
-	if (!str)
+
+	if (stype != IPMI_BINARY_STR)
+		/* ASCII or Unicode */
+		return strdup(str);
+
+	/* Binary data, dump it as hex. */
+	rstr = malloc(len * 2 + 1);
+	if (!rstr)
 		return NULL;
-	memset(str, 0, size+1);
 
-	if (size == 0) {
-		str[0] = '\0';
-		*offset = off;
-		return str;
-	}
-
-	switch (typecode) {
-	case 0:        /* Binary */
-		strncpy(str, buf2str(&data[off], len), size);
-		break;
-
-	case 1:        /* BCD plus */
-		for (k = 0; k < size; k++)
-			str[k] = bcd_plus[((data[off + k / 2] >> ((k % 2) ? 0 : 4)) & 0x0f)];
-		str[k] = '\0';
-		break;
-
-	case 2:        /* 6-bit ASCII */
-		for (i = j = 0; i < len; i += 3) {
-			u.bits = 0;
-			k = ((len - i) < 3 ? (len - i) : 3);
-#if WORDS_BIGENDIAN
-			u.chars[3] = data[off+i];
-			u.chars[2] = (k > 1 ? data[off+i+1] : 0);
-			u.chars[1] = (k > 2 ? data[off+i+2] : 0);
-			char_idx = 3;
-#else
-			memcpy((void *)&u.bits, &data[off+i], k);
-			char_idx = 0;
-#endif
-			for (k=0; k<4; k++) {
-				str[j++] = ((u.chars[char_idx] & 0x3f) + 0x20);
-				u.bits >>= 6;
-			}
-		}
-		str[j] = '\0';
-		break;
-
-	case 3:
-		memcpy(str, &data[off], size);
-		str[size] = '\0';
-		break;
-	}
-
-	off += len;
-	*offset = off;
-
-	return str;
+	for (i = 0; i < len; i++)
+		snprintf(rstr + (i * 2), 3, "2.2x", str[i]);
+	return rstr;
 }
 
 /* is_valid_filename - checks file/path supplied by user
@@ -1015,7 +951,7 @@ fru_area_print_chassis(struct ipmi_intf * intf, struct fru_info * fru,
 
  	i++;
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Chassis Part Number   : %s\n", fru_area);
@@ -1023,7 +959,7 @@ fru_area_print_chassis(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Chassis Serial        : %s\n", fru_area);
@@ -1034,7 +970,7 @@ fru_area_print_chassis(struct ipmi_intf * intf, struct fru_info * fru,
 	/* read any extra fields */
 	while ((i < fru_len) && (fru_data[i] != FRU_END_OF_FIELDS)) {
 		int j = i;
-		fru_area = get_fru_area_str(fru_data, &i);
+		fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 		if (fru_area) {
 			if (strlen(fru_area) > 0) {
 				printf(" Chassis Extra         : %s\n", fru_area);
@@ -1104,7 +1040,7 @@ fru_area_print_board(struct ipmi_intf * intf, struct fru_info * fru,
 	printf(" Board Mfg Date        : %s\n", ipmi_timestamp_string(ts));
 	i += 3;  /* skip mfg. date time */
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Board Mfg             : %s\n", fru_area);
@@ -1112,7 +1048,7 @@ fru_area_print_board(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Board Product         : %s\n", fru_area);
@@ -1120,7 +1056,7 @@ fru_area_print_board(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Board Serial          : %s\n", fru_area);
@@ -1128,7 +1064,7 @@ fru_area_print_board(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Board Part Number     : %s\n", fru_area);
@@ -1136,7 +1072,7 @@ fru_area_print_board(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0 && verbose > 0) {
 			printf(" Board FRU ID          : %s\n", fru_area);
@@ -1147,7 +1083,7 @@ fru_area_print_board(struct ipmi_intf * intf, struct fru_info * fru,
 	/* read any extra fields */
 	while ((i < fru_len) && (fru_data[i] != FRU_END_OF_FIELDS)) {
 		int j = i;
-		fru_area = get_fru_area_str(fru_data, &i);
+		fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 		if (fru_area) {
 			if (strlen(fru_area) > 0) {
 				printf(" Board Extra           : %s\n", fru_area);
@@ -1210,7 +1146,7 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 	 */
 	i = 3;
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Product Manufacturer  : %s\n", fru_area);
@@ -1218,7 +1154,7 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Product Name          : %s\n", fru_area);
@@ -1226,7 +1162,7 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Product Part Number   : %s\n", fru_area);
@@ -1234,7 +1170,7 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Product Version       : %s\n", fru_area);
@@ -1242,7 +1178,7 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Product Serial        : %s\n", fru_area);
@@ -1250,7 +1186,7 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0) {
 			printf(" Product Asset Tag     : %s\n", fru_area);
@@ -1258,7 +1194,7 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 		free_n(&fru_area);
 	}
 
-	fru_area = get_fru_area_str(fru_data, &i);
+	fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 	if (fru_area) {
 		if (strlen(fru_area) > 0 && verbose > 0) {
 			printf(" Product FRU ID        : %s\n", fru_area);
@@ -1269,7 +1205,7 @@ fru_area_print_product(struct ipmi_intf * intf, struct fru_info * fru,
 	/* read any extra fields */
 	while ((i < fru_len) && (fru_data[i] != FRU_END_OF_FIELDS)) {
 		int j = i;
-		fru_area = get_fru_area_str(fru_data, &i);
+		fru_area = get_fru_area_str(fru_data, &i, fru_len - i);
 		if (fru_area) {
 			if (strlen(fru_area) > 0) {
 				printf(" Product Extra         : %s\n", fru_area);
@@ -4805,7 +4741,8 @@ f_type, uint8_t f_index, char *f_string)
 		if (fru_area) {
 			free_n(&fru_area);
 		}
-		fru_area = (uint8_t *) get_fru_area_str(fru_data, &fru_field_offset);
+		fru_area = (uint8_t *) get_fru_area_str(fru_data, &fru_field_offset,
+			fru_section_len - fru_field_offset);
 	}
 
 	if (!FRU_FIELD_VALID(fru_area)) {
@@ -4973,7 +4910,8 @@ ipmi_fru_set_field_string_rebuild(struct ipmi_intf * intf, uint8_t fruId,
 	for (i = 0;i <= f_index; i++) {
 		fru_field_offset_tmp = fru_field_offset;
 		free_n(&fru_area);
-		fru_area = (uint8_t *) get_fru_area_str(fru_data_old, &fru_field_offset);
+		fru_area = (uint8_t *) get_fru_area_str(fru_data_old, &fru_field_offset,
+			fru_section_len - fru_field_offset);
 	}
 
 	if (!FRU_FIELD_VALID(fru_area)) {

--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -3042,7 +3042,7 @@ __ipmi_fru_print(struct ipmi_intf * intf, uint8_t id)
 int
 ipmi_fru_print(struct ipmi_intf * intf, struct sdr_record_fru_locator * fru)
 {
-	char desc[17];
+	char desc[IPMI_SDR_MAX_STR_SIZE];
 	uint8_t  bridged_request = 0;
 	uint32_t save_addr;
 	uint32_t save_channel;
@@ -3077,9 +3077,7 @@ ipmi_fru_print(struct ipmi_intf * intf, struct sdr_record_fru_locator * fru)
 		fru->device_id == 0)
 		return 0;
 
-	memset(desc, 0, sizeof(desc));
-	memcpy(desc, fru->id_string, __min(fru->id_code & 0x01f, sizeof(desc)));
-	desc[fru->id_code & 0x01f] = 0;
+	ipmi_get_sdr_string(fru->raw_id, desc);
 	printf("FRU Device Description : %s (ID %d)\n", desc, fru->device_id);
 
 	switch (fru->dev_type_modifier) {
@@ -3176,6 +3174,8 @@ ipmi_fru_print_all(struct ipmi_intf * intf)
 	/* FRU data.								    */
 	while ((header = ipmi_sdr_get_next_header(intf, itr)))
 	{
+		char desc[IPMI_SDR_MAX_STR_SIZE];
+
 		if (header->type == SDR_RECORD_TYPE_MC_DEVICE_LOCATOR ) {
 			/* Check the capabilities of the Management Controller Device */
 			mc = (struct sdr_record_mc_locator *)
@@ -3192,7 +3192,8 @@ ipmi_fru_print_all(struct ipmi_intf * intf)
 				/* set new target address to satellite controller */
 				intf->target_addr = mc->dev_slave_addr;
 
-				printf("FRU Device Description : %-16s\n", mc->id_string);
+				ipmi_get_sdr_string(mc->raw_id, desc);
+				printf("FRU Device Description : %-16s\n", desc);
 
 				/* print the FRU by issuing FRU commands to the satellite     */
 				/* controller.						      */

--- a/lib/ipmi_kontronoem.c
+++ b/lib/ipmi_kontronoem.c
@@ -54,7 +54,6 @@ extern int write_fru_area(struct ipmi_intf * intf, struct fru_info *fru,
 		uint8_t id, uint16_t soffset,
 		uint16_t doffset,  uint16_t length,
 		uint8_t *pFrubuf);
-extern char *get_fru_area_str(uint8_t *data, uint32_t *offset);
 
 static void ipmi_kontron_help(void);
 static int ipmi_kontron_set_serial_number(struct ipmi_intf *intf);
@@ -344,20 +343,23 @@ ipmi_kontron_set_serial_number(struct ipmi_intf *intf)
 	}
 	/* Position at Board Manufacturer */
 	fru_data_offset = (header.offset.board * 8) + 6;
-	fru_area = get_fru_area_str(fru_data, &fru_data_offset);
+	fru_area = get_fru_area_str(fru_data, &fru_data_offset,
+				    board_sec_len - fru_data_offset);
 	if (fru_area) {
 		free(fru_area);
 		fru_area = NULL;
 	}
 	/* Position at Board Product Name */
-	fru_area = get_fru_area_str(fru_data, &fru_data_offset);
+	fru_area = get_fru_area_str(fru_data, &fru_data_offset,
+				    board_sec_len - fru_data_offset);
 	if (fru_area) {
 		free(fru_area);
 		fru_area = NULL;
 	}
 	fru_data_offset_tmp = fru_data_offset;
 	/* Position at Serial Number */
-	fru_area = get_fru_area_str(fru_data, &fru_data_offset_tmp);
+	fru_area = get_fru_area_str(fru_data, &fru_data_offset_tmp,
+				    board_sec_len - fru_data_offset);
 	if (!fru_area) {
 		lprintf(LOG_ERR, "Failed to read FRU Area string.");
 		free(fru_data);
@@ -418,32 +420,37 @@ ipmi_kontron_set_serial_number(struct ipmi_intf *intf)
 	}
 	/* Position at Product Manufacturer */
 	fru_data_offset = (header.offset.product * 8) + 3;
-	fru_area = get_fru_area_str(fru_data, &fru_data_offset);
+	fru_area = get_fru_area_str(fru_data, &fru_data_offset,
+				    prod_sec_len - fru_data_offset);
 	if (fru_area) {
 		free(fru_area);
 		fru_area = NULL;
 	}
 	/* Position at Product Name */
-	fru_area = get_fru_area_str(fru_data, &fru_data_offset);
+	fru_area = get_fru_area_str(fru_data, &fru_data_offset,
+				    prod_sec_len - fru_data_offset);
 	if (fru_area) {
 		free(fru_area);
 		fru_area = NULL;
 	}
 	/* Position at Product Part */
-	fru_area = get_fru_area_str(fru_data, &fru_data_offset);
+	fru_area = get_fru_area_str(fru_data, &fru_data_offset,
+				    prod_sec_len - fru_data_offset);
 	if (fru_area) {
 		free(fru_area);
 		fru_area = NULL;
 	}
 	/* Position at Product Version */
-	fru_area = get_fru_area_str(fru_data, &fru_data_offset);
+	fru_area = get_fru_area_str(fru_data, &fru_data_offset,
+				    prod_sec_len - fru_data_offset);
 	if (fru_area) {
 		free(fru_area);
 		fru_area = NULL;
 	}
 	fru_data_offset_tmp = fru_data_offset;
 	/* Position at Serial Number */
-	fru_area = get_fru_area_str(fru_data, &fru_data_offset_tmp);
+	fru_area = get_fru_area_str(fru_data, &fru_data_offset_tmp,
+				    prod_sec_len - fru_data_offset);
 	if (!fru_area) {
 		lprintf(LOG_ERR, "Failed to read FRU Area string.");
 		free(sn);

--- a/lib/ipmi_sel.c
+++ b/lib/ipmi_sel.c
@@ -1869,26 +1869,34 @@ ipmi_sel_print_std_entry(struct ipmi_intf * intf, struct sel_event_record * evt)
 
 	/* lookup SDR entry based on sensor number and type */
 	if (sdr) {
+		char desc[IPMI_SDR_MAX_STR_SIZE];
+
 		printf("%s ", ipmi_get_sensor_type(intf,
 			evt->sel_type.standard_type.sensor_type));
 		switch (sdr->type) {
 		case SDR_RECORD_TYPE_FULL_SENSOR:
-			printf("%s", sdr->record.full->id_string);
+			ipmi_get_sdr_string(sdr->record.full->raw_id, desc);
+			printf("%s", desc);
 			break;
 		case SDR_RECORD_TYPE_COMPACT_SENSOR:
-			printf("%s", sdr->record.compact->id_string);
+			ipmi_get_sdr_string(sdr->record.compact->raw_id, desc);
+			printf("%s", desc);
 			break;
 		case SDR_RECORD_TYPE_EVENTONLY_SENSOR:
-			printf("%s", sdr->record.eventonly->id_string);
+			ipmi_get_sdr_string(sdr->record.eventonly->raw_id, desc);
+			printf("%s", desc);
 			break;
 		case SDR_RECORD_TYPE_FRU_DEVICE_LOCATOR:
-			printf("%s", sdr->record.fruloc->id_string);
+			ipmi_get_sdr_string(sdr->record.fruloc->raw_id, desc);
+			printf("%s", desc);
 			break;
 		case SDR_RECORD_TYPE_MC_DEVICE_LOCATOR:
-			printf("%s", sdr->record.mcloc->id_string);
+			ipmi_get_sdr_string(sdr->record.mcloc->raw_id, desc);
+			printf("%s", desc);
 			break;
 		case SDR_RECORD_TYPE_GENERIC_DEVICE_LOCATOR:
-			printf("%s", sdr->record.genloc->id_string);
+			ipmi_get_sdr_string(sdr->record.genloc->raw_id, desc);
+			printf("%s", desc);
 			break;
 		default:
 			printf("#%02x", evt->sel_type.standard_type.sensor_num);

--- a/lib/ipmi_sensor.c
+++ b/lib/ipmi_sensor.c
@@ -60,13 +60,12 @@ ipmi_sensor_get_sensor_reading_factors(
 	struct ipmi_rs * rsp;
 	uint8_t req_data[2];
 
-	char id[17];
+	char id[IPMI_SDR_MAX_STR_SIZE];
 
 	if (!intf || !sensor)
 		return -1;
 
-	memset(id, 0, sizeof(id));
-	memcpy(id, sensor->id_string, 16);
+	ipmi_get_sdr_string(sensor->raw_id, id);
 
 	req_data[0] = sensor->cmn.keys.sensor_num;
 	req_data[1] = reading;
@@ -602,6 +601,7 @@ ipmi_sensor_set_threshold(struct ipmi_intf *intf, int argc, char **argv)
 	struct ipmi_rs *rsp;
 	int i =0;
 	double val[10] = {0};
+	char desc[IPMI_SDR_MAX_STR_SIZE];
 
 	struct sdr_record_list *sdr;
 
@@ -703,11 +703,11 @@ ipmi_sensor_set_threshold(struct ipmi_intf *intf, int argc, char **argv)
 		return -1;
 	}
 
+	ipmi_get_sdr_string(sdr->record.full->raw_id, desc);
 
 	if (allUpper) {
 		settingMask = UPPER_NON_CRIT_SPECIFIED;
-		printf("Setting sensor \"%s\" %s threshold to %.3f\n",
-		       sdr->record.full->id_string,
+		printf("Setting sensor \"%s\" %s threshold to %.3f\n", desc,
 		       val2str(settingMask, threshold_vals), setting1);
 		ret = __ipmi_sensor_set_threshold(intf,
 						  sdr->record.common->keys.
@@ -718,8 +718,7 @@ ipmi_sensor_set_threshold(struct ipmi_intf *intf, int argc, char **argv)
 						  sdr->record.common->keys.channel);
 
 		settingMask = UPPER_CRIT_SPECIFIED;
-		printf("Setting sensor \"%s\" %s threshold to %.3f\n",
-		       sdr->record.full->id_string,
+		printf("Setting sensor \"%s\" %s threshold to %.3f\n", desc,
 		       val2str(settingMask, threshold_vals), setting2);
 		ret = __ipmi_sensor_set_threshold(intf,
 						  sdr->record.common->keys.
@@ -730,8 +729,7 @@ ipmi_sensor_set_threshold(struct ipmi_intf *intf, int argc, char **argv)
 						  sdr->record.common->keys.channel);
 
 		settingMask = UPPER_NON_RECOV_SPECIFIED;
-		printf("Setting sensor \"%s\" %s threshold to %.3f\n",
-		       sdr->record.full->id_string,
+		printf("Setting sensor \"%s\" %s threshold to %.3f\n", desc,
 		       val2str(settingMask, threshold_vals), setting3);
 		ret = __ipmi_sensor_set_threshold(intf,
 						  sdr->record.common->keys.
@@ -742,8 +740,7 @@ ipmi_sensor_set_threshold(struct ipmi_intf *intf, int argc, char **argv)
 						  sdr->record.common->keys.channel);
 	} else if (allLower) {
 		settingMask = LOWER_NON_RECOV_SPECIFIED;
-		printf("Setting sensor \"%s\" %s threshold to %.3f\n",
-		       sdr->record.full->id_string,
+		printf("Setting sensor \"%s\" %s threshold to %.3f\n", desc,
 		       val2str(settingMask, threshold_vals), setting1);
 		ret = __ipmi_sensor_set_threshold(intf,
 						  sdr->record.common->keys.
@@ -754,8 +751,7 @@ ipmi_sensor_set_threshold(struct ipmi_intf *intf, int argc, char **argv)
 						  sdr->record.common->keys.channel);
 
 		settingMask = LOWER_CRIT_SPECIFIED;
-		printf("Setting sensor \"%s\" %s threshold to %.3f\n",
-		       sdr->record.full->id_string,
+		printf("Setting sensor \"%s\" %s threshold to %.3f\n", desc,
 		       val2str(settingMask, threshold_vals), setting2);
 		ret = __ipmi_sensor_set_threshold(intf,
 						  sdr->record.common->keys.
@@ -766,8 +762,7 @@ ipmi_sensor_set_threshold(struct ipmi_intf *intf, int argc, char **argv)
 						  sdr->record.common->keys.channel);
 
 		settingMask = LOWER_NON_CRIT_SPECIFIED;
-		printf("Setting sensor \"%s\" %s threshold to %.3f\n",
-		       sdr->record.full->id_string,
+		printf("Setting sensor \"%s\" %s threshold to %.3f\n", desc,
 		       val2str(settingMask, threshold_vals), setting3);
 		ret = __ipmi_sensor_set_threshold(intf,
 						  sdr->record.common->keys.
@@ -864,8 +859,7 @@ ipmi_sensor_set_threshold(struct ipmi_intf *intf, int argc, char **argv)
 		}
 
 
-		printf("Setting sensor \"%s\" %s threshold to %.3f\n",
-		       sdr->record.full->id_string,
+		printf("Setting sensor \"%s\" %s threshold to %.3f\n", desc,
 		       val2str(settingMask, threshold_vals), setting1);
 
 		ret = __ipmi_sensor_set_threshold(intf,

--- a/lib/ipmi_string.c
+++ b/lib/ipmi_string.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2020 MontaVista Software, LLC.  All Rights Reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 
+ * Redistribution of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 
+ * Redistribution in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 
+ * Neither the name of MontaVista Software, Inc. or the names of
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * 
+ * This software is provided "AS IS," without a warranty of any kind.
+ * ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND WARRANTIES,
+ * INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY EXCLUDED.
+ * MONTAVISTA SOFTWARE, LLC. ("MONTAVISTA") AND ITS LICENSORS SHALL
+ * NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF
+ * USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+ * IN NO EVENT WILL MONTAVISTA OR ITS LICENSORS BE LIABLE FOR ANY LOST
+ * REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL,
+ * CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND
+ * REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF THE USE OF OR
+ * INABILITY TO USE THIS SOFTWARE, EVEN IF MONTAVISTA HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGES.
+ */
+
+#include <string.h>
+
+#include <ipmitool/ipmi_string.h>
+
+static int
+ipmi_get_unicode(unsigned int len,
+		 uint8_t **d, unsigned int in_len,
+		 char *out, unsigned int out_len)
+{
+	if (in_len < len)
+		return -1;
+	if (out_len < len)
+		return -1;
+
+	memcpy(out, *d, len);
+	*d += len;
+	return len;
+}
+
+static int
+ipmi_get_bcd_plus(unsigned int len,
+		  uint8_t **d, unsigned int in_len,
+		  char *out, unsigned int out_len)
+{
+	static char table[16] = {
+		'0', '1', '2', '3', '4', '5', '6', '7',
+		'8', '9', ' ', '-', '.', ':', ',', '_'
+	};
+	unsigned int bo;
+	unsigned int val = 0;
+	unsigned int i;
+	unsigned int real_length;
+	char         *out_s = out;
+
+	real_length = (in_len * 8) / 4;
+	if (len > real_length)
+		return -1;
+	if (len > out_len)
+		return -1;
+
+	bo = 0;
+	for (i=0; i<len; i++) {
+		switch (bo) {
+		case 0:
+			val = **d & 0xf;
+			bo = 4;
+			break;
+		case 4:
+			val = (**d >> 4) & 0xf;
+			(*d)++;
+			bo = 0;
+			break;
+		}
+		*out = table[val];
+		out++;
+	}
+
+	if (bo != 0)
+		(*d)++;
+
+	return out - out_s;
+}
+
+static int
+ipmi_get_6_bit_ascii(unsigned int len,
+		     uint8_t **d, unsigned int in_len,
+		     char *out, unsigned int out_len)
+{
+	static char table[64] = {
+		' ', '!', '"', '#', '$', '%', '&', '\'',
+		'(', ')', '*', '+', ',', '-', '.', '/', 
+		'0', '1', '2', '3', '4', '5', '6', '7',
+		'8', '9', ':', ';', '<', '=', '>', '?',
+		'&', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
+		'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 
+		'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W',
+		'X', 'Y', 'Z', '[', '\\', ']', '^', '_' 
+	};
+	unsigned int bo;
+	unsigned int val = 0;
+	unsigned int i;
+	unsigned int real_length;
+	char         *out_s = out;
+
+	real_length = (in_len * 8) / 6;
+	if (len > real_length)
+		return -1;
+	if (len > out_len)
+		return -1;
+
+	bo = 0;
+	for (i=0; i<len; i++) {
+		switch (bo) {
+		case 0:
+			val = **d & 0x3f;
+			bo = 6;
+			break;
+		case 2:
+			val = (**d >> 2) & 0x3f;
+			(*d)++;
+			bo = 0;
+			break;
+		case 4:
+			val = (**d >> 4) & 0xf;
+			(*d)++;
+			val |= (**d & 0x3) << 4;
+			bo = 2;
+			break;
+		case 6:
+			val = (**d >> 6) & 0x3;
+			(*d)++;
+			val |= (**d & 0xf) << 2;
+			bo = 4;
+			break;
+		}
+		*out = table[val];
+		out++;
+	}
+
+	if (bo != 0)
+		(*d)++;
+
+	return out - out_s;
+}
+
+static int
+ipmi_get_8_bit_ascii(unsigned int len,
+		     uint8_t **d, unsigned int in_len,
+		     char *out, unsigned int out_len)
+{
+	unsigned int j;
+    
+	if (len > in_len)
+		return -1;
+	if (len > out_len)
+		return -1;
+
+	for (j=0; j<len; j++) {
+		*out = **d;
+		out++;
+		(*d)++;
+	}
+	return len;
+}
+
+unsigned int
+ipmi_get_device_string(uint8_t ** const pinput, unsigned int in_len,
+		       int semantics, int force_unicode,
+		       enum ipmi_str_type_e *r_stype,
+		       unsigned int max_out_len, char *output)
+{
+	int type;
+	int len;
+	int olen = 0;
+	enum ipmi_str_type_e stype = IPMI_ASCII_STR;
+
+	if (max_out_len == 0)
+		goto out_done;
+
+	if (in_len <= 0) {
+		*output = '\0';
+		goto out_done;
+	}
+
+#if 0
+	/* Note that this is technically correct, but commonly ignored.
+	   0xc1 is invalid, but some FRU and SDR data still uses it.  Grr.
+	   The FRU stuff has to handle the end-of-area marker c1 itself,
+	   anyway, so this is relatively safe.  In a "correct" system you
+	   should never see a 0xc1 here, anyway. */
+	if (**pinput == 0xc1) {
+		*output = '\0';
+		(*pinput)++;
+		return 0;
+	}
+#endif
+
+	type = (**pinput >> 6) & 3;
+
+	/* Special case for FRU data, type 3 is unicode if the language is
+	   non-english. */
+	if ((force_unicode) && (type == 3)) {
+		type = 0;
+		force_unicode = 0;
+	}
+
+	len = **pinput & 0x3f;
+	(*pinput)++;
+	in_len--;
+	switch (type) {
+	case 0: /* Unicode */
+		olen = ipmi_get_unicode(len, pinput, in_len,
+					output, max_out_len);
+		if (semantics == IPMI_STR_FRU_SEMANTICS)
+			stype = IPMI_BINARY_STR;
+		else
+			stype = IPMI_UNICODE_STR;
+		break;
+	case 1: /* BCD Plus */
+		olen = ipmi_get_bcd_plus(len, pinput, in_len,
+					 output, max_out_len);
+		break;
+	case 2: /* 6-bit ASCII */
+		olen = ipmi_get_6_bit_ascii(len, pinput, in_len,
+					    output, max_out_len);
+		break;
+	case 3: /* 8-bit ASCII */
+		olen = ipmi_get_8_bit_ascii(len, pinput, in_len,
+					    output, max_out_len);
+		break;
+	default:
+		olen = 0;
+	}
+
+ out_done:
+	if (r_stype)
+	    *r_stype = stype;
+
+	if (olen < 0)
+		return 0;
+
+	return olen;
+}

--- a/src/ipmievd.c
+++ b/src/ipmievd.c
@@ -223,6 +223,7 @@ log_event(struct ipmi_event_intf * eintf, struct sel_event_record * evt)
 	struct ipmi_intf * intf = eintf->intf;
 	float trigger_reading = 0.0;
 	float threshold_reading = 0.0;
+	char id[IPMI_SDR_MAX_STR_SIZE];
 
 	if (!evt)
 		return;
@@ -279,10 +280,11 @@ log_event(struct ipmi_event_intf * eintf, struct sel_event_record * evt)
 					sdr->record.full, evt->sel_type.standard_type.event_data[2]);
 			}
 
+			ipmi_get_sdr_string(sdr->record.full->raw_id, id);
 			lprintf(LOG_NOTICE, "%s%s sensor %s %s %s (Reading %.*f %s Threshold %.*f %s)",
 				eintf->prefix,
 				type,
-				sdr->record.full->id_string,
+				id,
 				desc ? desc : "",
 				(evt->sel_type.standard_type.event_dir
 				 ? "Deasserted" : "Asserted"),
@@ -301,9 +303,9 @@ log_event(struct ipmi_event_intf * eintf, struct sel_event_record * evt)
 			/*
 			 * Discrete Event
 			 */
+			ipmi_get_sdr_string(sdr->record.full->raw_id, id);
 			lprintf(LOG_NOTICE, "%s%s sensor %s %s %s",
-				eintf->prefix, type,
-				sdr->record.full->id_string, desc ? desc : "",
+				eintf->prefix, type, id, desc ? desc : "",
 				(evt->sel_type.standard_type.event_dir
 				 ? "Deasserted" : "Asserted"));
 			if (((evt->sel_type.standard_type.event_data[0] >> 6) & 3) == 1) {
@@ -314,18 +316,18 @@ log_event(struct ipmi_event_intf * eintf, struct sel_event_record * evt)
 			/*
 			 * OEM Event
 			 */
+			ipmi_get_sdr_string(sdr->record.full->raw_id, id);
 			lprintf(LOG_NOTICE, "%s%s sensor %s %s %s",
-				eintf->prefix, type,
-				sdr->record.full->id_string, desc ? desc : "",
+				eintf->prefix, type, id, desc ? desc : "",
 				(evt->sel_type.standard_type.event_dir
 				 ? "Deasserted" : "Asserted"));
 		}
 		break;
 
 	case SDR_RECORD_TYPE_COMPACT_SENSOR:
+		ipmi_get_sdr_string(sdr->record.compact->raw_id, id);
 		lprintf(LOG_NOTICE, "%s%s sensor %s - %s %s",
-			eintf->prefix, type,
-			sdr->record.compact->id_string, desc ? desc : "",
+			eintf->prefix, type, id, desc ? desc : "",
 			(evt->sel_type.standard_type.event_dir
 			 ? "Deasserted" : "Asserted"));
 		break;


### PR DESCRIPTION
This has caused me grief several times.  The OpenIPMI SDR compiler will create BCD or 6-bit ASCII names per the spec, but ipmitool wouldn't handle them even though it has been in the spec since the beginning.

Add support the ipmitool for these.  This actually results in much neater code, IMHO.

The second patch switches FRU string handling over to the new string handling.  This is more important than you might imagine.  Binary handling of FRU data is broken, for one.  There is no end of data handling for FRU strings.  A carefully crafted FRU string might be able to cause an overrun in ipmitool and do bad things.

There are four semantic changes that should happen with these:
 * SDRs with BCD or 6-bit ASCII will print properly instead of printing gibberish.
 * SDR strings that are 16 bytes long will not print past the end of the string.  There were a bunch of:
      printf("xxx %s\n", sdr->xxx->id_string);
   thoughout the code, and the string in the SDR can be the full size.
 * FRU data with binary formatting will print as a hex dump instead of printing gibberish.
 * A FRU data string that went past the end of the area will no longer read past the end of the area.

I think all of these are good things.  But you can take just the SDR changes without the FRU changes, too.