### PR TITLE
Removing the Deprecated DellOEM command and Improving the code readability

### DIFF
--- a/include/ipmitool/ipmi_delloem.h
+++ b/include/ipmitool/ipmi_delloem.h
@@ -80,6 +80,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define watt                0x00
 #define IPMI_DELL_POWER_CAP 0xEA
 #define percent             0x03 
+#define OEM_DELL_CMD_END(def) {(def), NULL}
 
 /* Not on all Dell servers. If there, use it.*/
 typedef struct _tag_ipmi_dell_lcd_caps


### PR DESCRIPTION
Removing the Deprecated DellOEM command and Improving the code readability

1. Removing the Deprecated Dell OEM command 'setled'.
   This command is deprecated from 13th Generation Dell Servers onward.
2. Improving the code readability by
   i. Removing the nested else-if's in main function and using switch-case.
   ii. Removing the unnecessary function declaration,
       by moving the main function to the bottom of file.

Resolves ipmitool/ipmitool#225

Signed-off-by: mohan_pujari <mohan.hoy@gmail.com>