### PR TITLE
fru: Fix crashes on 6-bit ASCII strings

### DIFF
--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -175,8 +175,8 @@ char * get_fru_area_str(uint8_t * data, uint32_t * offset)
 		size = (len * 2);
 		break;
 	case 2:           /* 10b: 6-bit ASCII */
-		/* 4 chars per group of 1-3 bytes */
-		size = (((len * 4 + 2) / 3) & ~3);
+		/* 4 chars per group of 1-3 bytes, round up to 4 bytes boundary */
+		size = (len / 3 + 1) * 4;
 		break;
 	case 3:           /* 11b: 8-bit ASCII */
 		/* no length adjustment */


### PR DESCRIPTION
Fix calculation of the buffer size for decoded 6-bit ASCII
strings. Previously the program could allocate too a short buffer
that caused buffer overflows and segmentation fault crashes on
certain FRU contents.

Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>