### PR TITLE
ipmi_delloem.c: fix compiler warnings

### DIFF
--- a/lib/ipmi_delloem.c
+++ b/lib/ipmi_delloem.c
@@ -1579,7 +1579,6 @@ ipmi_macinfo_drac_idrac_virtual_mac(struct ipmi_intf* intf,uint8_t NicNum)
 	uint8_t msg_data[30];
 	uint8_t VirtualMacAddress [MACADDRESSLENGH];
 	uint8_t input_length=0;
-	uint8_t j;
 	uint8_t i;
 	if (NicNum != 0xff && NicNum != IDRAC_NIC_NUMBER) {
 		return 0;
@@ -1669,7 +1668,6 @@ ipmi_macinfo_drac_idrac_mac(struct ipmi_intf* intf,uint8_t NicNum)
 	uint8_t msg_data[30];
 	uint8_t input_length=0;
 	uint8_t iDRAC6MacAddressByte[MACADDRESSLENGH];
-	uint8_t j;
 	ipmi_macinfo_drac_idrac_virtual_mac(intf,NicNum);
 	if ((NicNum != 0xff && NicNum != IDRAC_NIC_NUMBER)
 			|| UseVirtualMacAddress != 0) {
@@ -1737,7 +1735,6 @@ ipmi_macinfo_10g(struct ipmi_intf* intf, uint8_t NicNum)
 	struct ipmi_rq req;
 	uint8_t msg_data[30];
 	uint8_t input_length=0;
-	uint8_t j;
 	uint8_t i;
 	uint8_t Total_No_NICs = 0;
 	InitEmbeddedNICMacAddressValues();
@@ -1800,7 +1797,6 @@ ipmi_macinfo_11g(struct ipmi_intf* intf, uint8_t NicNum)
 	struct ipmi_rq req;
 	uint8_t input_length = 0;
 	uint8_t i;
-	uint8_t j;
 	uint8_t len;
 	uint8_t loop_count;
 	uint8_t maxlen;


### PR DESCRIPTION
Remove unused variable j.

Signed-off-by: Heiko Thiery <heiko.thiery@gmail.com>