### PR TITLE
hpmfwupg: Clean up / refactor

### DIFF
--- a/include/ipmitool/ipmi_hpmfwupg.h
+++ b/include/ipmitool/ipmi_hpmfwupg.h
@@ -72,23 +72,6 @@ int ipmi_hpmfwupg_main(struct ipmi_intf *, int, char **);
 #define HPMFWUPG_FW_MISMATCH          0x83
 #define HPMFWUPG_ROLLBACK_DENIED      0x83
 
-/*
- * This error code is used as a temporary PATCH to
- * the latest Open ipmi driver.  This PATCH
- * will be removed once a new Open IPMI driver is released.
- * (Buggy version = 39)
- */
-#define ENABLE_OPENIPMI_V39_PATCH
-
-#ifdef ENABLE_OPENIPMI_V39_PATCH
-# define RETRY_COUNT_MAX 3
-static int errorCount;
-# define HPMFWUPG_IS_RETRYABLE(error)                                          \
- ((((error==0x83)||(error==0x82)||(error==0x80)) && (errorCount++<RETRY_COUNT_MAX))?TRUE:FALSE)
-#else
-# define HPMFWUPG_IS_RETRYABLE(error) FALSE
-#endif
-
 /* HPM FIRMWARE UPGRADE GENERAL DEFINITIONS */
 #define HPMFWUPG_PICMG_IDENTIFIER         0
 #define HPMFWUPG_VERSION_SIZE             6
@@ -799,8 +782,6 @@ typedef struct _VERSIONINFO {
 	unsigned char deferredActivationSupported;
 	char descString[HPMFWUPG_DESC_STRING_LENGTH + 1];
 }VERSIONINFO, *PVERSIONINFO;
-
-extern VERSIONINFO gVersionInfo[HPMFWUPG_COMPONENT_ID_MAX];
 
 #define TARGET_VER (0x01)
 #define ROLLBACK_VER (0x02)

--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -49,6 +49,23 @@
 # include <config.h>
 #endif
 
+/*
+ * This error code is used as a temporary PATCH to
+ * the latest Open ipmi driver.  This PATCH
+ * will be removed once a new Open IPMI driver is released.
+ * (Buggy version = 39)
+ */
+#define ENABLE_OPENIPMI_V39_PATCH
+
+#ifdef ENABLE_OPENIPMI_V39_PATCH
+# define RETRY_COUNT_MAX 3
+static int errorCount;
+# define HPMFWUPG_IS_RETRYABLE(error)                                          \
+ ((((error==0x83)||(error==0x82)||(error==0x80)) && (errorCount++<RETRY_COUNT_MAX))?TRUE:FALSE)
+#else
+# define HPMFWUPG_IS_RETRYABLE(error) FALSE
+#endif
+
 extern int verbose;
 
 VERSIONINFO gVersionInfo[HPMFWUPG_COMPONENT_ID_MAX];


### PR DESCRIPTION
- Drop a useless `extern` definition
- Remove static variable `errorCount` from header, move it to
  the c file where it is actually used if needed

Related to ipmitool/ipmitool#220

Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>