### PR TITLE
-I lanplus hpm check: fix garbage print

### DIFF
--- a/lib/ipmi_hpmfwupg.c
+++ b/lib/ipmi_hpmfwupg.c
@@ -1572,9 +1572,11 @@ HpmfwupgGetComponentProperties(struct ipmi_intf *intf,
 				val2str(rsp->ccode, completion_code_vals));
 		return HPMFWUPG_ERROR;
 	}
+
+	memcpy(&pCtx->resp, rsp->data, rsp->data_len);
+	((uint8_t*)&pCtx->resp)[rsp->data_len] = '\0';
 	switch (pCtx->req.selector) {
 	case HPMFWUPG_COMP_GEN_PROPERTIES:
-		memcpy(&pCtx->resp, rsp->data, sizeof(struct HpmfwupgGetGeneralPropResp));
 		if (verbose) {
 			lprintf(LOG_NOTICE, "GENERAL PROPERTIES");
 			lprintf(LOG_NOTICE, "-------------------------------");
@@ -1591,8 +1593,6 @@ HpmfwupgGetComponentProperties(struct ipmi_intf *intf,
 		}
 		break;
 	case HPMFWUPG_COMP_CURRENT_VERSION:
-		memcpy(&pCtx->resp, rsp->data,
-				sizeof(struct HpmfwupgGetCurrentVersionResp));
 		if (verbose) {
 			lprintf(LOG_NOTICE, "Current Version: ");
 			lprintf(LOG_NOTICE, " Major: %d",
@@ -1607,21 +1607,17 @@ HpmfwupgGetComponentProperties(struct ipmi_intf *intf,
 		}
 		break;
 	case HPMFWUPG_COMP_DESCRIPTION_STRING:
-		memcpy(&pCtx->resp, rsp->data,
-				sizeof(struct HpmfwupgGetDescStringResp));
 		if (verbose) {
 			char descString[HPMFWUPG_DESC_STRING_LENGTH + 1];
 			memcpy(descString,
 					pCtx->resp.Response.descStringResp.descString,
 					HPMFWUPG_DESC_STRING_LENGTH);
-			descString[HPMFWUPG_DESC_STRING_LENGTH] = '\0';
 			lprintf(LOG_NOTICE,
 					"Description string: %s\n",
 					descString);
 		}
 		break;
 	case HPMFWUPG_COMP_ROLLBACK_FIRMWARE_VERSION:
-		memcpy(&pCtx->resp, rsp->data, sizeof(struct HpmfwupgGetRollbackFwVersionResp));
 		if (verbose) {
 			lprintf(LOG_NOTICE, "Rollback FW Version: ");
 			lprintf(LOG_NOTICE, " Major: %d",
@@ -1636,7 +1632,6 @@ HpmfwupgGetComponentProperties(struct ipmi_intf *intf,
 		}
 		break;
 	case HPMFWUPG_COMP_DEFERRED_FIRMWARE_VERSION:
-		memcpy(&pCtx->resp, rsp->data, sizeof(struct HpmfwupgGetDeferredFwVersionResp));
 		if (verbose) {
 			lprintf(LOG_NOTICE, "Deferred FW Version: ");
 			lprintf(LOG_NOTICE, " Major: %d",
@@ -1652,7 +1647,6 @@ HpmfwupgGetComponentProperties(struct ipmi_intf *intf,
 		break;
 	case HPMFWUPG_COMP_OEM_PROPERTIES:
 		/* OEM Properties command */
-		memcpy(&pCtx->resp, rsp->data, sizeof(struct HpmfwupgGetOemProperties));
 		if (verbose) {
 			unsigned char i = 0;
 			lprintf(LOG_NOTICE,"OEM Properties: ");

--- a/src/plugins/lanplus/lanplus.c
+++ b/src/plugins/lanplus/lanplus.c
@@ -785,9 +785,7 @@ ipmi_lan_poll_single(struct ipmi_intf * intf)
 			if (extra_data_length > 0) {
 				rsp->data_len = extra_data_length;
 				memmove(rsp->data, rsp->data + offset, extra_data_length);
-				offset = 0;
-				payload_start = 0;
-				payload_size = extra_data_length;
+				memset(rsp->data + rsp->data_len, 0, IPMI_BUF_SIZE - rsp->data_len);
 			} else {
 				rsp->data_len = 0;
 			}


### PR DESCRIPTION
Two changes included in this branch:
1. zero the extra data buffer that are not containing any IPMI message
data.
2. copy only the HPM.1 property data to the pCtx response data buffer
based on the data length rather than the allowed max property size.

Resolves ipmitool/ipmitool#289

Signed-off-by: peng.wang@smartm.com <peng.wang@smartm.com>