### PR TITLE
ipmi_mc: Fix the IPM_DEV_FWREV1_MAJOR_MASK

### DIFF
--- a/include/ipmitool/ipmi_mc.h
+++ b/include/ipmitool/ipmi_mc.h
@@ -83,7 +83,7 @@ struct ipm_devid_rsp {
 #define IPM_DEV_DEVICE_ID_REV_MASK     (0x0F)	/* BCD-enoded             */
 
 #define IPM_DEV_FWREV1_AVAIL_MASK      (0x80)	/* 0 = normal operation   */
-#define IPM_DEV_FWREV1_MAJOR_MASK      (0x3f)	/* Major rev, BCD-encoded */
+#define IPM_DEV_FWREV1_MAJOR_MASK      (0x7f)	/* Major rev, BCD-encoded */
 
 #define IPM_DEV_IPMI_VER_MAJOR_MASK    (0x0F)	/* Major rev, BCD-encoded */
 #define IPM_DEV_IPMI_VER_MINOR_MASK    (0xF0)	/* Minor rev, BCD-encoded */


### PR DESCRIPTION
The IPM_DEV_FWREV1_MAJOR_MASK was incorrectly defined as 0x3F.
The spec indicates that the major firmware revision has 0~6 valid bits,
so the mask shall be 0x7F.

Tested: Verify a BMC that has a major version that is large than 0x3F,
        and ipmitool shows the correct major version.

Signed-off-by: Lei YU <yulei.sh@bytedance.com>