### PR TITLE
Feature/update GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   linux:
     strategy:
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,10 @@ jobs:
       run: make distcheck
 
   macos-catalina:
-    runs-on: macos-10.15
+    strategy:
+      matrix:
+        os: [ macos-10.15, macos-11 ]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: install dependencies


### PR DESCRIPTION
Update the CI configuraion to reflect the latest changes on GitHub.

See:
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/
https://github.blog/changelog/2021-09-29-github-actions-jobs-running-on-macos-latest-are-now-running-on-macos-big-sur-11/