### PR TITLE
chassis restart_cause: Add new causes

### DIFF
--- a/include/ipmitool/ipmi_strings.h
+++ b/include/ipmitool/ipmi_strings.h
@@ -49,6 +49,7 @@ extern const struct valstr ipmi_authtype_vals[];
 extern const struct valstr ipmi_channel_protocol_vals[];
 extern const struct valstr ipmi_channel_medium_vals[];
 extern const struct valstr ipmi_chassis_power_control_vals[];
+extern const struct valstr ipmi_chassis_restart_cause_vals[];
 extern const struct valstr ipmi_auth_algorithms[];
 extern const struct valstr ipmi_integrity_algorithms[];
 extern const struct valstr ipmi_encryption_algorithms[];

--- a/lib/ipmi_chassis.c
+++ b/lib/ipmi_chassis.c
@@ -378,42 +378,8 @@ ipmi_chassis_restart_cause(struct ipmi_intf * intf)
 		return -1;
 	}
 
-	printf("System restart cause: ");
-
-	switch (rsp->data[0] & 0xf) {
-	case 0:
-		printf("unknown\n");
-		break;
-	case 1:
-		printf("chassis power control command\n");
-		break;
-	case 2:
-		printf("reset via pushbutton\n");
-		break;
-	case 3:
-		printf("power-up via pushbutton\n");
-		break;
-	case 4:
-		printf("watchdog expired\n");
-		break;
-	case 5:
-		printf("OEM\n");
-		break;
-	case 6:
-		printf("power-up due to always-restore power policy\n");
-		break;
-	case 7:
-		printf("power-up due to restore-previous power policy\n");
-		break;
-	case 8:
-		printf("reset via PEF\n");
-		break;
-	case 9:
-		printf("power-cycle via PEF\n");
-		break;
-	default:
-		printf("invalid\n");
-	}
+	printf("System restart cause: %s\n",
+	       val2str(rsp->data[0] & 0xf, ipmi_chassis_restart_cause_vals));
 
 	return 0;
 }

--- a/lib/ipmi_strings.c
+++ b/lib/ipmi_strings.c
@@ -1265,6 +1265,25 @@ const struct valstr ipmi_chassis_power_control_vals[] = {
 	{ 0x00, NULL },
 };
 
+/*
+ * See Table 28-11, Get System Restart Cause Command
+ */
+const struct valstr ipmi_chassis_restart_cause_vals[] = {
+	{ 0x0, "unknown" },
+	{ 0x1, "chassis power control command" },
+	{ 0x2, "reset via pushbutton" },
+	{ 0x3, "power-up via pushbutton" },
+	{ 0x4, "watchdog expired" },
+	{ 0x5, "OEM" },
+	{ 0x6, "power-up due to always-restore power policy" },
+	{ 0x7, "power-up due to restore-previous power policy" },
+	{ 0x8, "reset via PEF" },
+	{ 0x9, "power-cycle via PEF" },
+	{ 0xa, "soft reset" },
+	{ 0xb, "power-up via RTC wakeup" },
+	{ 0xFF, NULL },
+};
+
 const struct valstr ipmi_auth_algorithms[] = {
 	{ IPMI_AUTH_RAKP_NONE,      "none"      },
 	{ IPMI_AUTH_RAKP_HMAC_SHA1, "hmac_sha1" },


### PR DESCRIPTION
Add 'soft reset' and 'power-up by RTC wakeup' causes
from IPMI 2.0 spec.

Resolves ipmitool/ipmitool#329

Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>