### PR TITLE
SEL printing: Invert the threshold inequality when an event is deasserted

### DIFF
--- a/lib/ipmi_sel.c
+++ b/lib/ipmi_sel.c
@@ -1955,8 +1955,20 @@ ipmi_sel_print_std_entry(struct ipmi_intf * intf, struct sel_event_record * evt)
 				(trigger_reading==(int)trigger_reading) ? 0 : 2,
 				trigger_reading);
 		if (threshold_reading_provided) {
+			/* According to Table 29-6, Event Data byte 1 contains,
+			 * among other info, the offset from the Threshold type
+			 * code. According to Table 42-2, all even offsets
+			 * are 'going low', and all odd offsets are 'going high'
+			 */
+			bool going_high =
+			        (evt->sel_type.standard_type.event_data[0]
+			         & EVENT_OFFSET_MASK) % 2;
+			if (evt->sel_type.standard_type.event_dir) {
+				/* Event is de-asserted so the inequality is reversed */
+				going_high = !going_high;
+			}
 			printf(" %s Threshold %.*f %s",
-					((evt->sel_type.standard_type.event_data[0] & 0xf) % 2) ? ">" : "<",
+					going_high ? ">" : "<",
 					(threshold_reading==(int)threshold_reading) ? 0 : 2,
 					threshold_reading,
 					ipmi_sdr_get_unit_string(sdr->record.common->unit.pct,


### PR DESCRIPTION
The choice of `>` or `<` when printing the threshold inequality currently only depends on whether it is an upper or lower threshold. This is correct when the event is asserted, but when the event is deasserted the inequality is reversed and therefore the current code can give confusing results, e.g.:
```
 3cb | 07/17/2022 | 06:15:39 | Temperature ps1_inlet_temp | Upper Non-critical going high | Deasserted | Reading 43.94 > Threshold 44.88 degrees C
```
(Note `Reading 43.94 > Threshold 44.88`)

This PR fixes this by inverting the sign when the event is deasserted:

```
 3cb | 17/07/22 | 07:15:39 BST | Temperature ps1_inlet_temp | Upper Non-critical going high | Deasserted | Reading 43.94 < Threshold 44.88 degrees C
```