### PR TITLE
ipmi_fru.c: Provide missing function declarations

### DIFF
--- a/lib/ipmi_fru.c
+++ b/lib/ipmi_fru.c
@@ -60,6 +60,13 @@ static const char *section_id[4] = {
 	"Board Section",
 	"Product Section"
 };
+/* From lib/ipmi_hpmfwupg.c: */
+uint16_t
+ipmi_intf_get_max_request_data_size(struct ipmi_intf * intf);
+
+/* From src/plugins/ipmi_intf.c: */
+uint16_t
+ipmi_intf_get_max_response_data_size(struct ipmi_intf * intf);
 
 static const char * combined_voltage_desc[] = {
 	"12 V",


### PR DESCRIPTION
Fixes build with clang-15+

Signed-off-by: Khem Raj <raj.khem@gmail.com>