### PR TITLE
Update IANA PEN Registry URL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ MAINTAINERCLEANFILES = Makefile.in aclocal.m4 configure configure-stamp \
 	$(distdir).tar.gz $(distdir).tar.bz2
 
 SUBDIRS = lib src include doc contrib control
-IANA_PEN = http://www.iana.org/assignments/enterprise-numbers
+IANA_PEN = http://www.iana.org/assignments/enterprise-numbers.txt
 
 dist-hook:
 	cp control/ipmitool.spec $(distdir)


### PR DESCRIPTION
On macOS Monterey 12.6.1 when installing using the recommended method in INSTALL, the cryptic message `Failed to initialize the OEM info dictionary` is output. 

```
➜  ipmitool git:(master) ./bootstrap && ./configure && make && sudo make install
+ aclocal
...
/usr/bin/install -c -m 644 ./README ./COPYING ./AUTHORS ./ChangeLog /usr/local/share/doc/ipmitool
rm enterprise-numbers
➜  ipmitool git:(master) ipmitool 
Failed to initialize the OEM info dictionary
```

It seems that the registry file downloaded from `IANA_PEN` https://github.com/ipmitool/ipmitool/blob/master/Makefile.am#L44 and  parsed in https://github.com/ipmitool/ipmitool/blob/master/lib/ipmi_strings.c#L1523-L1528 is bad because it's not expecting an HTML file but some other custom file format.

Looking at the website http://www.iana.org/assignments/enterprise-numbers, the "raw" tab has a link to http://www.iana.org/assignments/enterprise-numbers.txt which looks more like what `ipmitool` is expecting. 

``` 
➜  ipmitool-code-vespa git:(master) ./configure && make && sudo make install
checking build system type... x86_64-apple-darwin21.6.0
....
/usr/bin/install -c -m 644 ./README ./COPYING ./AUTHORS ./ChangeLog /usr/local/share/doc/ipmitool
rm enterprise-numbers
➜  ipmitool-code-vespa git:(master) ipmitool       
No hostname specified!
```

