### PR TITLE
fru: Add decoder for multirec system mgmt records

### DIFF
--- a/include/ipmitool/ipmi_fru.h
+++ b/include/ipmitool/ipmi_fru.h
@@ -127,6 +127,7 @@ struct fru_area_product {
 #ifdef HAVE_PRAGMA_PACK
 #pragma pack(1)
 #endif
+/* See Table 16-1 of "IPMI FRU Information Storage Specification" */
 struct fru_multirec_header {
 #define FRU_RECORD_TYPE_POWER_SUPPLY_INFORMATION 0x00
 #define FRU_RECORD_TYPE_DC_OUTPUT 0x01
@@ -136,6 +137,8 @@ struct fru_multirec_header {
 #define FRU_RECORD_TYPE_EXTENDED_COMPATIBILITY 0x05
 #define FRU_RECORD_TYPE_OEM_EXTENSION	0xc0
 	uint8_t type;
+#define FRU_RECORD_FORMAT_EOL_MASK 0x80
+#define FRU_RECORD_FORMAT_VER_MASK 0x0F
 	uint8_t format;
 	uint8_t len;
 	uint8_t record_checksum;
@@ -239,6 +242,43 @@ struct fru_multirec_dcload {
 }ATTRIBUTE_PACKING;
 #ifdef HAVE_PRAGMA_PACK
 #pragma pack(0)
+#endif
+
+#ifdef HAVE_PRAGMA_PACK
+#pragma pack(push, 1)
+#endif
+/*
+ * In accordance with Table 18-7 of "IPMI Platform Management FRU Information
+ * Storage Definition v1.0"
+ */
+struct fru_multirec_mgmt {
+#define FRU_MULTIREC_MGMT_SUBTYPE_MIN 0x01
+#define FRU_MULTIREC_MGMT_SUBTYPE_MAX 0x07
+	uint8_t subtype;
+#define FRU_MULTIREC_MGMT_SYSURL 0x01
+#define FRU_MULTIREC_MGMT_CMPURL 0x04
+#define FRU_MULTIREC_MGMT_URL_MINLEN 16
+#define FRU_MULTIREC_MGMT_URL_MAXLEN 256
+
+#define FRU_MULTIREC_MGMT_SYSNAME 0x02
+#define FRU_MULTIREC_MGMT_CMPNAME 0x05
+#define FRU_MULTIREC_MGMT_NAME_MINLEN 8
+#define FRU_MULTIREC_MGMT_NAME_MAXLEN 64
+
+#define FRU_MULTIREC_MGMT_SYSPINGADDR 0x03
+#define FRU_MULTIREC_MGMT_CMPPINGADDR 0x06
+#define FRU_MULTIREC_MGMT_PINGADDR_MINLEN 8
+#define FRU_MULTIREC_MGMT_PINGADDR_MAXLEN 64
+
+#define FRU_MULTIREC_MGMT_UUID 0x07
+#define FRU_MULTIREC_MGMT_UUID_LEN 16
+
+#define FRU_MULTIREC_MGMT_DATA_MAXLEN FRU_MULTIREC_MGMT_URL_MAXLEN
+	uint8_t data[];
+} ATTRIBUTE_PACKING;
+
+#ifdef HAVE_PRAGMA_PACK
+#pragma pack(pop)
 #endif
 
 #ifdef HAVE_PRAGMA_PACK

--- a/include/ipmitool/ipmi_mc.h
+++ b/include/ipmitool/ipmi_mc.h
@@ -211,6 +211,21 @@ typedef struct {
 
 parsed_guid_t ipmi_parse_guid(void *guid, ipmi_guid_mode_t guid_mode);
 
+/**
+ * Convert a binary GUID/UUID to a canonical hex string form.
+ * If the version/encoding of the source data is unknown,
+ * dump the source data as a simple hex string.
+ *
+ * @param[out] str  The string representation of GUID
+ * @param[in]  data The source binary GUID data
+ * @param[in]  mode The conversion mode, use GUID_AUTO for automatic detection
+ *
+ * @returns The parsed GUID structure
+ */
+parsed_guid_t
+ipmi_guid2str(char *str, const void *data, ipmi_guid_mode_t mode);
+#define GUID_STR_MAXLEN 36 /* 8+4+4+4+12 bytes plus the dashes */
+
 int _ipmi_mc_get_guid(struct ipmi_intf *intf, ipmi_guid_t *guid);
 
 #ifdef HAVE_PRAGMA_PACK


### PR DESCRIPTION
* Add a decoder for System Management records in the Multirecord area
* Refactor GUID/UUID decoding: Use the same code for `mc guid` and
   for `fru print` to decode the GUID and System Unique ID in
   System Management records in the Multirecord Area.
* Fix some type errors in calls to printf/sprintf in GUID decoder

Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>