### PR TITLE
Fix shift out of bound undefined behavior

### DIFF
--- a/lib/helper.c
+++ b/lib/helper.c
@@ -66,7 +66,7 @@ extern int verbose;
 
 uint32_t buf2long(uint8_t * buf)
 {
-	return (uint32_t)(buf[3] << 24 | buf[2] << 16 | buf[1] << 8 | buf[0]);
+	return (uint32_t)(buf[3]) << 24 | buf[2] << 16 | buf[1] << 8 | buf[0];
 }
 
 uint16_t buf2short(uint8_t * buf)


### PR DESCRIPTION
Since that the C implicit conversion will do Integral promotion on buf to 'int'
(which is a unsigned short) If the value of buf[3] is larger than 127, than the
int cannot hold it, result in an undefined behavior.